### PR TITLE
feat: add pr_number as an optional output on the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,8 @@ outputs:
     description: Value is "true" if changes were committed back to the repository.
   commit:
     description: Full hash of the created commit. Only present if the "changes" output is "true".
+  pr_number:
+    description: Number of the submitted pull request. Only present if a pull request is submitted.
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,3 +70,9 @@ if [ -n "$commit" ]; then
 else
     echo "changes=false" >> "$GITHUB_OUTPUT"
 fi
+
+pr_number=$(echo "$output" | grep "Pull Request Number:" | sed 's/.*: //')
+
+if [ -n "$pr_number" ]; then 
+   echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+fi

--- a/tests/trestlebot/test_bot.py
+++ b/tests/trestlebot/test_bot.py
@@ -184,7 +184,7 @@ def test_run(tmp_repo: Tuple[str, Repo]) -> None:
         mock_push.return_value = "Mocked result"
 
         # Test running the bot
-        commit_sha = bot.run(
+        commit_sha, pr_number = bot.run(
             working_dir=repo_path,
             branch="main",
             commit_name="Test User",
@@ -196,6 +196,7 @@ def test_run(tmp_repo: Tuple[str, Repo]) -> None:
             dry_run=False,
         )
         assert commit_sha != ""
+        assert pr_number == 0
 
         # Verify that the commit is made
         commit = next(repo.iter_commits())
@@ -223,7 +224,7 @@ def test_run_dry_run(tmp_repo: Tuple[str, Repo]) -> None:
         mock_push.return_value = "Mocked result"
 
         # Test running the bot
-        commit_sha = bot.run(
+        commit_sha, pr_number = bot.run(
             working_dir=repo_path,
             branch="main",
             commit_name="Test User",
@@ -235,6 +236,7 @@ def test_run_dry_run(tmp_repo: Tuple[str, Repo]) -> None:
             dry_run=True,
         )
         assert commit_sha != ""
+        assert pr_number == 0
 
         mock_push.assert_not_called()
 
@@ -246,7 +248,7 @@ def test_empty_commit(tmp_repo: Tuple[str, Repo]) -> None:
     repo_path, repo = tmp_repo
 
     # Test running the bot
-    commit_sha = bot.run(
+    commit_sha, pr_number = bot.run(
         working_dir=repo_path,
         branch="main",
         commit_name="Test User",
@@ -258,6 +260,7 @@ def test_empty_commit(tmp_repo: Tuple[str, Repo]) -> None:
         dry_run=True,
     )
     assert commit_sha == ""
+    assert pr_number == 0
 
     clean(repo_path, repo)
 
@@ -275,7 +278,7 @@ def test_run_check_only(tmp_repo: Tuple[str, Repo]) -> None:
         bot.RepoException,
         match="Check only mode is enabled and diff detected. Manual intervention on main is required.",
     ):
-        _ = bot.run(
+        _, _ = bot.run(
             working_dir=repo_path,
             branch="main",
             commit_name="Test User",
@@ -348,7 +351,7 @@ def test_run_with_provider(tmp_repo: Tuple[str, Repo]) -> None:
         f.write("Test content")
 
     mock = Mock(spec=GitProvider)
-    mock.create_pull_request.return_value = "10"
+    mock.create_pull_request.return_value = 10
     mock.parse_repository.return_value = ("ns", "repo")
 
     repo.create_remote("origin", url="git.test.com/test/repo.git")
@@ -357,7 +360,7 @@ def test_run_with_provider(tmp_repo: Tuple[str, Repo]) -> None:
         mock_push.return_value = "Mocked result"
 
         # Test running the bot
-        commit_sha = bot.run(
+        commit_sha, pr_number = bot.run(
             working_dir=repo_path,
             branch="test",
             commit_name="Test User",
@@ -371,6 +374,7 @@ def test_run_with_provider(tmp_repo: Tuple[str, Repo]) -> None:
             dry_run=False,
         )
         assert commit_sha != ""
+        assert pr_number == 10
 
         # Verify that the commit is made
         commit = next(repo.iter_commits())

--- a/trestlebot/cli.py
+++ b/trestlebot/cli.py
@@ -254,7 +254,7 @@ def run() -> None:
     # Assume it is a successful run, if the bot
     # throws an exception update the exit code accordingly
     try:
-        commit_sha = bot.run(
+        commit_sha, pr_number = bot.run(
             working_dir=args.working_dir,
             branch=args.branch,
             commit_name=args.committer_name,
@@ -272,7 +272,11 @@ def run() -> None:
 
         # Print the full commit sha
         if commit_sha:
-            print(f"Commit Hash: {commit_sha}")  # noqa
+            print(f"Commit Hash: {commit_sha}")  # noqa: T201
+
+        # Print the pr number
+        if pr_number:
+            print(f"Pull Request Number: {pr_number}")  # noqa: T201
 
     except Exception as e:
         exit_code = handle_exception(e)


### PR DESCRIPTION
## Description

Adds the pull request number as an output of the action for further steps in workflow to facilitate automation like assigning reviewers or making comments.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Update unit tests
- [X] Integration test w/ GitHub Actions: **TODO**

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
