### PR TITLE
fix: updates comparison for ssp type in get_trestle_model_dir

### DIFF
--- a/trestlebot/tasks/authored/types.py
+++ b/trestlebot/tasks/authored/types.py
@@ -64,7 +64,7 @@ def get_trestle_model_dir(input_type: str) -> str:
         return const.MODEL_DIR_PROFILE
     elif input_type == AuthoredType.COMPDEF.value:
         return const.MODEL_DIR_COMPDEF
-    elif input_type is AuthoredType.SSP.value:
+    elif input_type == AuthoredType.SSP.value:
         return const.MODEL_DIR_SSP
     else:
         raise AuthoredObjectException(f"Invalid authored type {input_type}")


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes `invalid author type` when using trestlebot for ssp autofix

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- Manual test completed

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
