### PR TITLE
PSCE-239: feat: adds validation for YAML trestle rules

### DIFF
--- a/tests/trestlebot/transformers/test_validations.py
+++ b/tests/trestlebot/transformers/test_validations.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+#    Copyright 2023 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Test for Validations."""
+from typing import Any, Dict
+
+from trestlebot.transformers.validations import (
+    ValidationHandler,
+    ValidationOutcome,
+    parameter_validation,
+)
+
+
+def test_parameter_validation(valid_rule_data: Dict[str, Any]) -> None:
+    """Test parameter validation with valid data."""
+    result: ValidationOutcome = ValidationOutcome(errors=[], valid=True)
+    parameter_validation(valid_rule_data, result)
+    assert result.valid
+
+
+def test_parameter_validation_with_error(
+    invalid_param_rule_data: Dict[str, Any]
+) -> None:
+    """Test parameter validation with invalid parameter."""
+    result: ValidationOutcome = ValidationOutcome(errors=[], valid=True)
+    parameter_validation(invalid_param_rule_data, result)
+    assert not result.valid
+    assert len(result.errors) == 1
+    assert (
+        result.errors[0].error_message
+        == "Default value must be one of the alternative values"
+    )
+
+
+def test_parameter_validation_with_handler(
+    invalid_param_rule_data: Dict[str, Any]
+) -> None:
+    """Test parameter validation with handler."""
+    result: ValidationOutcome = ValidationOutcome(errors=[], valid=True)
+    handler = ValidationHandler(parameter_validation)
+    handler.handle(invalid_param_rule_data, result)
+    assert not result.valid
+    assert len(result.errors) == 1
+    assert (
+        result.errors[0].error_message
+        == "Default value must be one of the alternative values"
+    )

--- a/tests/trestlebot/transformers/test_yaml_transformer.py
+++ b/tests/trestlebot/transformers/test_yaml_transformer.py
@@ -21,6 +21,7 @@ import pytest
 from tests.testutils import YAML_TEST_DATA_PATH
 from trestlebot.transformers.base_transformer import RulesTransformerException
 from trestlebot.transformers.trestle_rule import TrestleRule
+from trestlebot.transformers.validations import ValidationHandler, parameter_validation
 from trestlebot.transformers.yaml_transformer import (
     FromRulesYAMLTransformer,
     ToRulesYAMLTransformer,
@@ -84,6 +85,24 @@ def test_rules_transform_with_invalid_rule() -> None:
 
     with pytest.raises(
         RulesTransformerException, match="Invalid YAML file: 1 validation error .*"
+    ):
+        transformer.transform(rule_file_info)
+
+
+def test_rules_transform_with_additional_validation() -> None:
+    """Test rules transform with additional validation."""
+    # load rule from path and close the file
+    # get the file info as a string
+    rule_path = YAML_TEST_DATA_PATH / "test_rule_invalid_params.yaml"
+    rule_file = open(rule_path, "r")
+    rule_file_info = rule_file.read()
+    rule_file.close()
+    validation_handler_chain = ValidationHandler(parameter_validation)
+    transformer = ToRulesYAMLTransformer(validation_handler_chain)
+
+    with pytest.raises(
+        RulesTransformerException,
+        match=".*Default value must be one of the alternative values",
     ):
         transformer.transform(rule_file_info)
 

--- a/trestlebot/transformers/csv_transformer.py
+++ b/trestlebot/transformers/csv_transformer.py
@@ -14,7 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-"""CSV Tranformer for rule authoring."""
+"""CSV Transformer for rule authoring."""
 
 import csv
 import json

--- a/trestlebot/transformers/validations.py
+++ b/trestlebot/transformers/validations.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python
+
+#    Copyright 2023 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+Trestle Validation for rule authoring.
+
+This is meant to be extensible for future validations.
+Base rule validation and utility functions are defined here.
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from trestlebot import const
+
+
+logger = logging.getLogger(__name__)
+
+
+class RuleValidationError(BaseModel):
+    """RuleValidationError model."""
+
+    field_name: str
+    error_message: str
+
+
+class ValidationOutcome(BaseModel):
+    """ValidationOutcome model."""
+
+    errors: List[RuleValidationError]
+    valid: bool
+
+
+class ValidationHandler:
+    def __init__(  # type: ignore
+        self, validate_fn: Callable[[Any, ValidationOutcome], None], next_handler=None
+    ) -> None:
+        self.validate_fn: Callable[[Any, ValidationOutcome], None] = validate_fn
+        self.next_handler: Optional[ValidationHandler] = next_handler
+
+    def handle(self, data: Any, result: ValidationOutcome) -> None:
+        self.validate_fn(data, result)
+        if self.next_handler:
+            self.next_handler.handle(data, result)
+
+
+# TODO(jpower432): Create a class for Profile validation to ensure unique
+# entries exists in the workspace.
+
+
+def parameter_validation(data: Dict[str, Any], result: ValidationOutcome) -> None:
+    """Parameter logic additions validation."""
+    rule_info: Dict[str, Any] = data.get(const.RULE_INFO_TAG, {})
+    parameter_data: Dict[str, Any] = rule_info.get(const.PARAMETER, {})
+
+    if not parameter_data:
+        logger.debug("No parameter data found")
+        return  # No parameter data, nothing to validate
+
+    default_value = parameter_data.get(const.DEFAULT_VALUE, "")
+    alternative_values: Dict[str, Any] = parameter_data.get(
+        const.ALTERNATIVE_VALUES, {}
+    )
+
+    if not default_value:
+        add_validation_error(result, const.PARAMETER, "Default value is required")
+
+    if not alternative_values:
+        add_validation_error(result, const.PARAMETER, "Alternative values are required")
+
+    default_value_alt = alternative_values.get("default", "")
+
+    if not default_value_alt or default_value_alt != default_value:
+        add_validation_error(
+            result,
+            const.PARAMETER,
+            "Default value must be one of the alternative values",
+        )
+
+
+def add_validation_error(result: ValidationOutcome, field: str, error_msg: str) -> None:
+    """Add a validation error to the result."""
+    validation_error = RuleValidationError(field_name=field, error_message=error_msg)
+    result.errors.append(validation_error)
+    result.valid = False


### PR DESCRIPTION
## Description

Adds basic validation implementation which allows for additional validation on top of pydantic.

- The added validation currently checks that the parameter and alternatives values are structured correctly

### Some Ideas for future validation

- Check that the profiles referenced are accessible.

Blocked #50 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Unit tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
