### PR TITLE
fix: adds an example row to final CSV to account for skipped rows

### DIFF
--- a/tests/data/yaml/test_complete_rule_no_params.yaml
+++ b/tests/data/yaml/test_complete_rule_no_params.yaml
@@ -7,6 +7,6 @@ x-trestle-rule-info:
     include-controls:
       - id: ac-1
 x-trestle-component-info:
-  name: Component 1
-  description: Component 1 description
+  name: Component 2
+  description: Component 2 description
   type: service

--- a/tests/trestlebot/tasks/test_rule_transform_task.py
+++ b/tests/trestlebot/tasks/test_rule_transform_task.py
@@ -54,11 +54,22 @@ def test_rule_transform_task(tmp_trestle_dir: str) -> None:
     assert orig_comp is not None
     assert orig_comp.metadata.title == "Component definition for test_comp"
     assert orig_comp.components is not None
-    assert len(orig_comp.components) == 1
+    assert len(orig_comp.components) == 2
 
     component = orig_comp.components[0]
 
     assert component.props is not None
+    assert component.title == "Component 2"
+    assert len(component.props) == 2
+    assert component.props[0].name == RULE_ID
+    assert component.props[0].value == "example_rule_2"
+    assert component.props[1].name == RULE_DESCRIPTION
+    assert component.props[1].value == "My rule description for example rule 2"
+
+    component = orig_comp.components[1]
+
+    assert component.props is not None
+    assert component.title == "Component 1"
     assert len(component.props) == 5
     assert component.props[0].name == RULE_ID
     assert component.props[0].value == "example_rule_1"

--- a/trestlebot/transformers/csv_transformer.py
+++ b/trestlebot/transformers/csv_transformer.py
@@ -52,6 +52,7 @@ from trestlebot.transformers.trestle_rule import (
     Parameter,
     Profile,
     TrestleRule,
+    get_default_rule,
 )
 
 
@@ -218,7 +219,13 @@ class CSVBuilder:
             fieldnames.extend(self._csv_columns.get_required_column_names())
             fieldnames.extend(self._csv_columns.get_optional_column_names())
 
+            # The trestle csv_to_oscal_cd task skips the header row and the
+            # first row which is meant to have descriptions. We will just write a default right now.
+            default_rule: TrestleRule = get_default_rule()
+            example_row = self._transformer.transform(default_rule)
+
             writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
             writer.writeheader()
+            writer.writerow(example_row)
             for row in self._rows:
                 writer.writerow(row)

--- a/trestlebot/transformers/trestle_rule.py
+++ b/trestlebot/transformers/trestle_rule.py
@@ -66,3 +66,21 @@ class TrestleRule(BaseModel):
     component: ComponentInfo
     parameter: Optional[Parameter]
     profile: Profile
+
+
+def get_default_rule() -> TrestleRule:
+    """Create a default rule for template purposes."""
+    return TrestleRule(
+        name="example rule",
+        description="example description",
+        component=ComponentInfo(
+            name="example component",
+            type="service",
+            description="example description",
+        ),
+        profile=Profile(
+            description="example profile",
+            href="example href",
+            include_controls=[Control(id="example")],
+        ),
+    )


### PR DESCRIPTION
## Description

The csv_to_oscal_cd task skips the first two rows. The output CSV only had a header row so the first rule was always skipped. This change adds an example row to where the descriptions would be.

Blocked by #55 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Updated unit test

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
