### PR TITLE
PSCE-258 - feat: adds filtering by profile to AuthoredComponentDefinition create…

### DIFF
--- a/tests/trestlebot/tasks/test_rule_transform_task.py
+++ b/tests/trestlebot/tasks/test_rule_transform_task.py
@@ -56,20 +56,24 @@ def test_rule_transform_task(tmp_trestle_dir: str) -> None:
     assert orig_comp.components is not None
     assert len(orig_comp.components) == 2
 
-    component = orig_comp.components[0]
+    component = next(
+        (comp for comp in orig_comp.components if comp.title == "Component 2"), None
+    )
 
+    assert component is not None
     assert component.props is not None
-    assert component.title == "Component 2"
     assert len(component.props) == 2
     assert component.props[0].name == RULE_ID
     assert component.props[0].value == "example_rule_2"
     assert component.props[1].name == RULE_DESCRIPTION
     assert component.props[1].value == "My rule description for example rule 2"
 
-    component = orig_comp.components[1]
+    component = next(
+        (comp for comp in orig_comp.components if comp.title == "Component 1"), None
+    )
 
+    assert component is not None
     assert component.props is not None
-    assert component.title == "Component 1"
     assert len(component.props) == 5
     assert component.props[0].name == RULE_ID
     assert component.props[0].value == "example_rule_1"


### PR DESCRIPTION
…_new_default

## Description

Allow `rules-view-dir` controls to be filtered by a catalog or profile.

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Unit tests added

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
