### PR TITLE
feat: configure logger for module and control from actions files

### DIFF
--- a/actions/autosync/action.yml
+++ b/actions/autosync/action.yml
@@ -70,6 +70,10 @@ inputs:
     description: Email address used for the commit author. Defaults to the email of whoever triggered this workflow run.
     required: false
     default: ${{ github.actor }}@users.noreply.github.com
+  verbose:
+    description: Enable verbose logging
+    required: false
+    default: "false"
 
 outputs:
   changes:

--- a/actions/autosync/auto-sync-entrypoint.sh
+++ b/actions/autosync/auto-sync-entrypoint.sh
@@ -49,6 +49,10 @@ if [[ ${INPUT_CHECK_ONLY} == true ]]; then
     command+=" --check-only"
 fi
 
+if [[ ${INPUT_VERBOSE} == true ]]; then
+    command+=" --verbose"
+fi
+
 # Only set the token value when is a target branch so pull requests can be created
 if [[ -n ${INPUT_TARGET_BRANCH} ]]; then
   if [[ -z ${GITHUB_TOKEN} ]]; then

--- a/actions/rules-transform/action.yml
+++ b/actions/rules-transform/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: Email address used for the commit author. Defaults to the email of whoever triggered this workflow run.
     required: false
     default: ${{ github.actor }}@users.noreply.github.com
+  verbose:
+    description: Enable verbose logging
+    required: false
+    default: "false"
 
 outputs:
   changes:

--- a/actions/rules-transform/rules-transform-entrypoint.sh
+++ b/actions/rules-transform/rules-transform-entrypoint.sh
@@ -34,6 +34,10 @@ command="trestlebot-rules-transform \
         --target-branch=\"${INPUT_TARGET_BRANCH}\" \
         --skip-items=\"${INPUT_SKIP_ITEMS}\""
 
+# Conditionally include flags
+if [[ ${INPUT_VERBOSE} == true ]]; then
+    command+=" --verbose"
+fi
 
 # Only set the token value when is a target branch so pull requests can be created
 if [[ -n ${INPUT_TARGET_BRANCH} ]]; then

--- a/trestlebot/bot.py
+++ b/trestlebot/bot.py
@@ -180,7 +180,7 @@ def run(
                     )
                     # Parse remote url to get repository information for pull request
                     namespace, repo_name = git_provider.parse_repository(remote.url)
-                    logger.debug("Detected namespace {namespace} and {repo_name}")
+                    logger.debug(f"Detected namespace {namespace} and {repo_name}")
 
                     pr_number = git_provider.create_pull_request(
                         ns=namespace,

--- a/trestlebot/entrypoints/autosync.py
+++ b/trestlebot/entrypoints/autosync.py
@@ -28,10 +28,7 @@ import sys
 from typing import List
 
 from trestlebot import const
-from trestlebot.entrypoints.entrypoint_base import (
-    EntrypointBase,
-    comma_sep_to_list,
-)
+from trestlebot.entrypoints.entrypoint_base import EntrypointBase, comma_sep_to_list
 from trestlebot.entrypoints.log import set_log_level_from_args
 from trestlebot.tasks.assemble_task import AssembleTask
 from trestlebot.tasks.authored import types

--- a/trestlebot/entrypoints/autosync.py
+++ b/trestlebot/entrypoints/autosync.py
@@ -27,10 +27,12 @@ import logging
 import sys
 from typing import List
 
-import trestle.common.log as log
-
 from trestlebot import const
-from trestlebot.entrypoints.entrypoint_base import EntrypointBase, comma_sep_to_list
+from trestlebot.entrypoints.entrypoint_base import (
+    EntrypointBase,
+    comma_sep_to_list,
+)
+from trestlebot.entrypoints.log import set_log_level_from_args
 from trestlebot.tasks.assemble_task import AssembleTask
 from trestlebot.tasks.authored import types
 from trestlebot.tasks.base_task import TaskBase
@@ -94,7 +96,7 @@ class AutoSyncEntrypoint(EntrypointBase):
     def run(self, args: argparse.Namespace) -> None:
         """Run the autosync entrypoint."""
 
-        log.set_log_level_from_args(args=args)
+        set_log_level_from_args(args)
 
         pre_tasks: List[TaskBase] = []
 

--- a/trestlebot/entrypoints/entrypoint_base.py
+++ b/trestlebot/entrypoints/entrypoint_base.py
@@ -52,7 +52,11 @@ class EntrypointBase:
     def setup_common_arguments(self) -> None:
         """Setup arguments for the entrypoint."""
         self.parser.add_argument(
-            "-v", "--verbose", action="store_true", help="Enable verbose mode"
+            "-v",
+            "--verbose",
+            help="Display verbose output",
+            action="count",
+            default=0,
         )
         self.parser.add_argument(
             "--branch",

--- a/trestlebot/entrypoints/log.py
+++ b/trestlebot/entrypoints/log.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+
+#    Copyright 2023 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Configure logger for trestlebot and trestle."""
+
+import argparse
+import logging
+import sys
+
+import trestle.common.log as log
+
+_logger = logging.getLogger('trestlebot')
+
+
+def set_log_level_from_args(args: argparse.Namespace) -> None:
+    """Set the log level from the args for trestle and trestlebot."""
+
+    # Setup the trestle logger
+    log.set_log_level_from_args(args=args)
+
+    if args.verbose == 1:
+        configure_logger(logging.DEBUG)
+    else:
+        configure_logger(logging.INFO)
+
+
+def configure_logger(level: int = logging.INFO) -> None:
+    """Configure the logger."""
+    _logger.setLevel(level=level)
+
+    # Create a StreamHandler to send non-error logs to stdout
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.DEBUG)
+
+    # Create a StreamHandler to send error logs to stderr
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.ERROR)
+
+    # Create a formatter and set it on both handlers
+    log_formatter = logging.Formatter('%(name)s:%(lineno)d %(levelname)s: %(message)s')
+    stdout_handler.setFormatter(log_formatter)
+    stderr_handler.setFormatter(log_formatter)
+
+    _logger.addHandler(stdout_handler)
+    _logger.addHandler(stderr_handler)

--- a/trestlebot/entrypoints/log.py
+++ b/trestlebot/entrypoints/log.py
@@ -22,7 +22,8 @@ import sys
 
 import trestle.common.log as log
 
-_logger = logging.getLogger('trestlebot')
+
+_logger = logging.getLogger("trestlebot")
 
 
 def set_log_level_from_args(args: argparse.Namespace) -> None:
@@ -50,7 +51,7 @@ def configure_logger(level: int = logging.INFO) -> None:
     stderr_handler.setLevel(logging.ERROR)
 
     # Create a formatter and set it on both handlers
-    log_formatter = logging.Formatter('%(name)s:%(lineno)d %(levelname)s: %(message)s')
+    log_formatter = logging.Formatter("%(name)s:%(lineno)d %(levelname)s: %(message)s")
     stdout_handler.setFormatter(log_formatter)
     stderr_handler.setFormatter(log_formatter)
 

--- a/trestlebot/entrypoints/rule_transform.py
+++ b/trestlebot/entrypoints/rule_transform.py
@@ -18,9 +18,11 @@ import argparse
 import logging
 from typing import List
 
-import trestle.common.log as log
-
-from trestlebot.entrypoints.entrypoint_base import EntrypointBase, comma_sep_to_list
+from trestlebot.entrypoints.entrypoint_base import (
+    EntrypointBase,
+    comma_sep_to_list,
+)
+from trestlebot.entrypoints.log import set_log_level_from_args
 from trestlebot.tasks.base_task import TaskBase
 from trestlebot.tasks.rule_transform_task import RuleTransformTask
 from trestlebot.transformers.validations import ValidationHandler, parameter_validation
@@ -58,7 +60,7 @@ class RulesTransformEntrypoint(EntrypointBase):
     def run(self, args: argparse.Namespace) -> None:
         """Run the rule transform entrypoint."""
 
-        log.set_log_level_from_args(args=args)
+        set_log_level_from_args(args)
 
         # Configure the YAML Transformer for the task
         validation_handler: ValidationHandler = ValidationHandler(parameter_validation)

--- a/trestlebot/entrypoints/rule_transform.py
+++ b/trestlebot/entrypoints/rule_transform.py
@@ -18,10 +18,7 @@ import argparse
 import logging
 from typing import List
 
-from trestlebot.entrypoints.entrypoint_base import (
-    EntrypointBase,
-    comma_sep_to_list,
-)
+from trestlebot.entrypoints.entrypoint_base import EntrypointBase, comma_sep_to_list
 from trestlebot.entrypoints.log import set_log_level_from_args
 from trestlebot.tasks.base_task import TaskBase
 from trestlebot.tasks.rule_transform_task import RuleTransformTask


### PR DESCRIPTION
## Description

Adds proper configuration of trestlebot logger along with compliance-trestle logger
Allows verbosity to be set from the actions files

Related: PSCE-256

## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Local testing done per the guide
- [X] Actions integration testing - https://github.com/jpower432/cautious-potato/actions/runs/6554397597/job/17801314217

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
