### PR TITLE
refactor: updates "filter" variables to avoid clash with builtin func…

### DIFF
--- a/tests/trestlebot/tasks/test_assemble_task.py
+++ b/tests/trestlebot/tasks/test_assemble_task.py
@@ -96,13 +96,13 @@ def test_assemble_task_with_skip(tmp_trestle_dir: str, skip_list: List[str]) -> 
 
     mock = Mock(spec=AuthorObjectBase)
 
-    filter = ModelFilter(skip_list, ["*"])
+    model_filter = ModelFilter(skip_list, ["*"])
 
     assemble_task = AssembleTask(
         working_dir=tmp_trestle_dir,
         authored_model=AuthoredType.CATALOG.value,
         markdown_dir=cat_md_dir,
-        filter=filter,
+        model_filter=model_filter,
     )
 
     with patch(

--- a/tests/trestlebot/tasks/test_regenerate_task.py
+++ b/tests/trestlebot/tasks/test_regenerate_task.py
@@ -87,13 +87,13 @@ def test_regenerate_task_with_skip(tmp_trestle_dir: str, skip_list: List[str]) -
 
     mock = Mock(spec=AuthorObjectBase)
 
-    filter = ModelFilter(skip_list, ["*"])
+    model_filter = ModelFilter(skip_list, ["*"])
 
     regenerate_task = RegenerateTask(
         working_dir=tmp_trestle_dir,
         authored_model=AuthoredType.CATALOG.value,
         markdown_dir=cat_md_dir,
-        filter=filter,
+        model_filter=model_filter,
     )
 
     with patch(

--- a/tests/trestlebot/tasks/test_rule_transform_task.py
+++ b/tests/trestlebot/tasks/test_rule_transform_task.py
@@ -117,9 +117,9 @@ def test_rule_transform_task_with_skip(tmp_trestle_dir: str) -> None:
     setup_rules_view(trestle_root, test_comp, test_rules_dir)
     transformer = ToRulesYAMLTransformer()
 
-    filter = ModelFilter([test_comp], [])
+    model_filter = ModelFilter([test_comp], [])
     rule_transform_task = RuleTransformTask(
-        tmp_trestle_dir, test_rules_dir, transformer, filter=filter
+        tmp_trestle_dir, test_rules_dir, transformer, model_filter=model_filter
     )
     return_code = rule_transform_task.execute()
     assert return_code == 0

--- a/trestlebot/entrypoints/autosync.py
+++ b/trestlebot/entrypoints/autosync.py
@@ -120,7 +120,8 @@ class AutoSyncEntrypoint(EntrypointBase):
                 logger.error("Must set ssp_index_path when using SSP as oscal model.")
                 sys.exit(const.ERROR_EXIT_CODE)
 
-            filter: ModelFilter = ModelFilter(
+            # Allow any model to be skipped from the args, by default include all
+            model_filter: ModelFilter = ModelFilter(
                 skip_patterns=comma_sep_to_list(args.skip_items),
                 include_patterns=["*"],
             )
@@ -133,7 +134,7 @@ class AutoSyncEntrypoint(EntrypointBase):
                     authored_model=args.oscal_model,
                     markdown_dir=args.markdown_path,
                     ssp_index_path=args.ssp_index_path,
-                    filter=filter,
+                    model_filter=model_filter,
                 )
                 pre_tasks.append(assemble_task)
             else:
@@ -145,7 +146,7 @@ class AutoSyncEntrypoint(EntrypointBase):
                     authored_model=args.oscal_model,
                     markdown_dir=args.markdown_path,
                     ssp_index_path=args.ssp_index_path,
-                    filter=filter,
+                    model_filter=model_filter,
                 )
                 pre_tasks.append(regenerate_task)
             else:

--- a/trestlebot/entrypoints/create_cd.py
+++ b/trestlebot/entrypoints/create_cd.py
@@ -115,7 +115,7 @@ class CreateCDEntrypoint(EntrypointBase):
 
         # In this case we only want to do the transformation and generation for this component
         # definition, so we skip all other component definitions and components.
-        workspace_filter: ModelFilter = ModelFilter(
+        model_filter: ModelFilter = ModelFilter(
             [], [args.compdef_name, args.component_title, f"{RULE_PREFIX}*"]
         )
 
@@ -123,7 +123,7 @@ class CreateCDEntrypoint(EntrypointBase):
             working_dir=args.working_dir,
             rules_view_dir=RULES_VIEW_DIR,
             rule_transformer=transformer,
-            filter=workspace_filter,
+            model_filter=model_filter,
         )
         pre_tasks.append(rule_transform_task)
 
@@ -131,7 +131,7 @@ class CreateCDEntrypoint(EntrypointBase):
             working_dir=args.working_dir,
             authored_model=AuthoredType.COMPDEF.value,
             markdown_dir=args.markdown_path,
-            filter=workspace_filter,
+            model_filter=model_filter,
         )
         pre_tasks.append(regenerate_task)
 

--- a/trestlebot/entrypoints/rule_transform.py
+++ b/trestlebot/entrypoints/rule_transform.py
@@ -63,7 +63,8 @@ class RulesTransformEntrypoint(EntrypointBase):
         validation_handler: ValidationHandler = ValidationHandler(parameter_validation)
         transformer: ToRulesYAMLTransformer = ToRulesYAMLTransformer(validation_handler)
 
-        filter: ModelFilter = ModelFilter(
+        # Allow any model to be skipped from the args, by default include all
+        model_filter: ModelFilter = ModelFilter(
             skip_patterns=comma_sep_to_list(args.skip_items),
             include_patterns=["*"],
         )
@@ -72,7 +73,7 @@ class RulesTransformEntrypoint(EntrypointBase):
             working_dir=args.working_dir,
             rules_view_dir=args.rules_view_path,
             rule_transformer=transformer,
-            filter=filter,
+            model_filter=model_filter,
         )
         pre_tasks: List[TaskBase] = [rule_transform_task]
 

--- a/trestlebot/tasks/assemble_task.py
+++ b/trestlebot/tasks/assemble_task.py
@@ -40,7 +40,7 @@ class AssembleTask(TaskBase):
         authored_model: str,
         markdown_dir: str,
         ssp_index_path: str = "",
-        filter: Optional[ModelFilter] = None,
+        model_filter: Optional[ModelFilter] = None,
     ) -> None:
         """
         Initialize assemble task.
@@ -50,13 +50,14 @@ class AssembleTask(TaskBase):
             authored_model: String representation of model type
             markdown_dir: Location of directory to write Markdown in
             ssp_index_path: Path of ssp index JSON in the workspace
-            filter: Optional filter to apply to the task to include or exclude models from processing
+            model_filter: Optional filter to apply to the task to include or exclude models
+            from processing
         """
 
         self._authored_model = authored_model
         self._markdown_dir = markdown_dir
         self._ssp_index_path = ssp_index_path
-        super().__init__(working_dir, filter)
+        super().__init__(working_dir, model_filter)
 
     def execute(self) -> int:
         """Execute task"""

--- a/trestlebot/tasks/base_task.py
+++ b/trestlebot/tasks/base_task.py
@@ -66,16 +66,16 @@ class TaskBase(ABC):
     Abstract base class for tasks with a work directory.
     """
 
-    def __init__(self, working_dir: str, filter: Optional[ModelFilter]) -> None:
+    def __init__(self, working_dir: str, model_filter: Optional[ModelFilter]) -> None:
         """
         Initialize base task.
 
         Args:
             working_dir: Working directory to complete operations in.
-            filter: Model filter to use for this task.
+            model_filter: Model filter to use for this task.
         """
         self._working_dir = working_dir
-        self.filter: Optional[ModelFilter] = filter
+        self.filter: Optional[ModelFilter] = model_filter
 
     @property
     def working_dir(self) -> str:

--- a/trestlebot/tasks/regenerate_task.py
+++ b/trestlebot/tasks/regenerate_task.py
@@ -40,7 +40,7 @@ class RegenerateTask(TaskBase):
         authored_model: str,
         markdown_dir: str,
         ssp_index_path: str = "",
-        filter: Optional[ModelFilter] = None,
+        model_filter: Optional[ModelFilter] = None,
     ) -> None:
         """
         Initialize regenerate task.
@@ -50,13 +50,14 @@ class RegenerateTask(TaskBase):
             authored_model: String representation of model type
             markdown_dir: Location of directory to write Markdown in
             ssp_index_path: Path of ssp index JSON in the workspace
-            filter: Optional filter to apply to the task to include or exclude models from processing.
+            model_filter: Optional filter to apply to the task to include or exclude models
+            from processing.
         """
 
         self._authored_model = authored_model
         self._markdown_dir = markdown_dir
         self._ssp_index_path = ssp_index_path
-        super().__init__(working_dir, filter)
+        super().__init__(working_dir, model_filter)
 
     def execute(self) -> int:
         """Execute task"""

--- a/trestlebot/tasks/rule_transform_task.py
+++ b/trestlebot/tasks/rule_transform_task.py
@@ -46,7 +46,7 @@ class RuleTransformTask(TaskBase):
         working_dir: str,
         rules_view_dir: str,
         rule_transformer: ToRulesYAMLTransformer,
-        filter: Optional[ModelFilter] = None,
+        model_filter: Optional[ModelFilter] = None,
     ) -> None:
         """
         Initialize transform task.
@@ -55,7 +55,8 @@ class RuleTransformTask(TaskBase):
             working_dir: Working directory to complete operations in
             rule_view_dir: Location of directory containing components with to read rules from
             rule_transformer: Transformer to use for rule transformation to TrestleRule
-            filter: Optional filter to apply to the task to include or exclude models from processing.
+            model_filter: Optional filter to apply to the task to include or exclude models
+            from processing.
 
         Notes:
             The rule_view_dir is expected to be a directory containing directories of
@@ -66,7 +67,7 @@ class RuleTransformTask(TaskBase):
 
         self._rule_view_dir = rules_view_dir
         self._rule_transformer: ToRulesYAMLTransformer = rule_transformer
-        super().__init__(working_dir, filter)
+        super().__init__(working_dir, model_filter)
 
     def execute(self) -> int:
         """Execute task"""


### PR DESCRIPTION
## Description

Update "filter" variable used to represent ModelFilter to a more descriptive name and to avoid clash with the builtin function.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Refactor/Cleanup

## How has this been tested?

- [X] Regression Testing
  - create-cd - https://github.com/jpower432/cautious-potato/actions/runs/6660396616/job/18101427570
  - autosync - https://github.com/jpower432/cautious-potato/actions/runs/6660395646/job/18101424518
  - rules-transform - https://github.com/jpower432/cautious-potato/actions/runs/6667619916/job/18121425131
  - regeneration - https://github.com/jpower432/cautious-potato/actions/runs/6667615064/job/18121411246


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
