### PR TITLE
refactor: decouple AuthoredObject configuration and from Tasks

### DIFF
--- a/tests/trestlebot/tasks/authored/test_types.py
+++ b/tests/trestlebot/tasks/authored/test_types.py
@@ -23,8 +23,8 @@ import pytest
 from tests import testutils
 from trestlebot.tasks.authored import types
 from trestlebot.tasks.authored.base_authored import (
+    AuthoredObjectBase,
     AuthoredObjectException,
-    AuthorObjectBase,
 )
 from trestlebot.tasks.authored.catalog import AuthoredCatalog
 from trestlebot.tasks.authored.compdef import AuthoredComponentDefinition
@@ -41,7 +41,7 @@ markdown_dir = "md_ssp"
 def test_get_authored_catalog(tmp_trestle_dir: str) -> None:
     """Test get authored type for catalogs"""
 
-    authored_object: AuthorObjectBase = types.get_authored_object(
+    authored_object: AuthoredObjectBase = types.get_authored_object(
         types.AuthoredType.CATALOG.value, tmp_trestle_dir, ""
     )
 
@@ -52,7 +52,7 @@ def test_get_authored_catalog(tmp_trestle_dir: str) -> None:
 def test_get_authored_profile(tmp_trestle_dir: str) -> None:
     """Test get authored type for catalogs"""
 
-    authored_object: AuthorObjectBase = types.get_authored_object(
+    authored_object: AuthoredObjectBase = types.get_authored_object(
         types.AuthoredType.PROFILE.value, tmp_trestle_dir, ""
     )
 
@@ -64,7 +64,7 @@ def test_get_authored_compdef(tmp_trestle_dir: str) -> None:
     """Test get authored type for catalogs"""
 
     # Test with profile
-    authored_object: AuthorObjectBase = types.get_authored_object(
+    authored_object: AuthoredObjectBase = types.get_authored_object(
         types.AuthoredType.COMPDEF.value, tmp_trestle_dir, ""
     )
 
@@ -83,7 +83,7 @@ def test_get_authored_ssp(tmp_trestle_dir: str) -> None:
         _ = types.get_authored_object(types.AuthoredType.SSP.value, tmp_trestle_dir, "")
 
     # Test with profile
-    authored_object: AuthorObjectBase = types.get_authored_object(
+    authored_object: AuthoredObjectBase = types.get_authored_object(
         types.AuthoredType.SSP.value, tmp_trestle_dir, ssp_index_path
     )
 

--- a/tests/trestlebot/tasks/test_assemble_task.py
+++ b/tests/trestlebot/tasks/test_assemble_task.py
@@ -34,7 +34,7 @@ from trestle.oscal import profile as oscal_prof
 
 from tests import testutils
 from trestlebot.tasks.assemble_task import AssembleTask
-from trestlebot.tasks.authored.base_authored import AuthorObjectBase
+from trestlebot.tasks.authored.base_authored import AuthoredObjectBase
 from trestlebot.tasks.authored.types import AuthoredType
 from trestlebot.tasks.base_task import ModelFilter
 
@@ -58,7 +58,7 @@ def test_assemble_task_isolated(tmp_trestle_dir: str) -> None:
     cat_generate = CatalogGenerate()
     assert cat_generate._run(args) == 0
 
-    mock = Mock(spec=AuthorObjectBase)
+    mock = Mock(spec=AuthoredObjectBase)
 
     assemble_task = AssembleTask(
         tmp_trestle_dir,
@@ -94,7 +94,7 @@ def test_assemble_task_with_skip(tmp_trestle_dir: str, skip_list: List[str]) -> 
     cat_generate = CatalogGenerate()
     assert cat_generate._run(args) == 0
 
-    mock = Mock(spec=AuthorObjectBase)
+    mock = Mock(spec=AuthoredObjectBase)
 
     model_filter = ModelFilter(skip_list, ["*"])
 

--- a/tests/trestlebot/tasks/test_assemble_task.py
+++ b/tests/trestlebot/tasks/test_assemble_task.py
@@ -35,7 +35,10 @@ from trestle.oscal import profile as oscal_prof
 from tests import testutils
 from trestlebot.tasks.assemble_task import AssembleTask
 from trestlebot.tasks.authored.base_authored import AuthoredObjectBase
-from trestlebot.tasks.authored.types import AuthoredType
+from trestlebot.tasks.authored.catalog import AuthoredCatalog
+from trestlebot.tasks.authored.compdef import AuthoredComponentDefinition
+from trestlebot.tasks.authored.profile import AuthoredProfile
+from trestlebot.tasks.authored.ssp import AuthoredSSP, SSPIndex
 from trestlebot.tasks.base_task import ModelFilter
 
 
@@ -59,22 +62,19 @@ def test_assemble_task_isolated(tmp_trestle_dir: str) -> None:
     assert cat_generate._run(args) == 0
 
     mock = Mock(spec=AuthoredObjectBase)
-
-    assemble_task = AssembleTask(
-        tmp_trestle_dir,
-        AuthoredType.CATALOG.value,
-        cat_md_dir,
-        "",
-    )
+    mock.get_trestle_root.return_value = tmp_trestle_dir
+    assemble_task = AssembleTask(mock, cat_md_dir, "1.0.0")
 
     with patch(
-        "trestlebot.tasks.authored.types.get_authored_object"
-    ) as mock_get_authored_object:
-        mock_get_authored_object.return_value = mock
+        "trestlebot.tasks.authored.types.get_trestle_model_dir"
+    ) as mock_get_trestle_model_dir:
+        mock_get_trestle_model_dir.return_value = "catalogs"
 
         assert assemble_task.execute() == 0
 
-        mock.assemble.assert_called_once_with(markdown_path=md_path)
+        mock.assemble.assert_called_once_with(
+            markdown_path=md_path, version_tag="1.0.0"
+        )
 
 
 @pytest.mark.parametrize(
@@ -95,20 +95,15 @@ def test_assemble_task_with_skip(tmp_trestle_dir: str, skip_list: List[str]) -> 
     assert cat_generate._run(args) == 0
 
     mock = Mock(spec=AuthoredObjectBase)
-
+    mock.get_trestle_root.return_value = tmp_trestle_dir
     model_filter = ModelFilter(skip_list, ["*"])
 
-    assemble_task = AssembleTask(
-        working_dir=tmp_trestle_dir,
-        authored_model=AuthoredType.CATALOG.value,
-        markdown_dir=cat_md_dir,
-        model_filter=model_filter,
-    )
+    assemble_task = AssembleTask(mock, cat_md_dir, cat_md_dir, model_filter)
 
     with patch(
-        "trestlebot.tasks.authored.types.get_authored_object"
-    ) as mock_get_authored_object:
-        mock_get_authored_object.return_value = mock
+        "trestlebot.tasks.authored.types.get_trestle_model_dir"
+    ) as mock_get_trestle_model_dir:
+        mock_get_trestle_model_dir.return_value = "catalogs"
 
         assert assemble_task.execute() == 0
         mock.assemble.assert_not_called()
@@ -128,12 +123,9 @@ def test_catalog_assemble_task(tmp_trestle_dir: str) -> None:
     )
     orig_time = cat.metadata.last_modified
 
-    assemble_task = AssembleTask(
-        tmp_trestle_dir,
-        AuthoredType.CATALOG.value,
-        cat_md_dir,
-        "",
-    )
+    catalog = AuthoredCatalog(tmp_trestle_dir)
+    assemble_task = AssembleTask(catalog, cat_md_dir)
+
     assert assemble_task.execute() == 0
 
     # Get new last modified time and verify catalog was modified
@@ -157,12 +149,9 @@ def test_profile_assemble_task(tmp_trestle_dir: str) -> None:
     )
     orig_time = prof.metadata.last_modified
 
-    assemble_task = AssembleTask(
-        tmp_trestle_dir,
-        AuthoredType.PROFILE.value,
-        prof_md_dir,
-        "",
-    )
+    profile = AuthoredProfile(tmp_trestle_dir)
+    assemble_task = AssembleTask(profile, prof_md_dir)
+
     assert assemble_task.execute() == 0
 
     # Get new last modified time adn verify profile was modified
@@ -191,12 +180,9 @@ def test_compdef_assemble_task(tmp_trestle_dir: str) -> None:
     )
     orig_time = comp.metadata.last_modified
 
-    assemble_task = AssembleTask(
-        tmp_trestle_dir,
-        AuthoredType.COMPDEF.value,
-        compdef_md_dir,
-        "",
-    )
+    compdef = AuthoredComponentDefinition(tmp_trestle_dir)
+    assemble_task = AssembleTask(compdef, compdef_md_dir)
+
     assert assemble_task.execute() == 0
 
     # Get new last modified time and verify component was modified
@@ -217,32 +203,13 @@ def test_ssp_assemble_task(tmp_trestle_dir: str) -> None:
     ssp_generate = SSPGenerate()
     assert ssp_generate._run(args) == 0
 
-    assemble_task = AssembleTask(
-        tmp_trestle_dir,
-        AuthoredType.SSP.value,
-        ssp_md_dir,
-        ssp_index_path,
-    )
+    ssp_index = SSPIndex(ssp_index_path)
+
+    ssp = AuthoredSSP(tmp_trestle_dir, ssp_index)
+    assemble_task = AssembleTask(ssp, ssp_md_dir)
+
     assert assemble_task.execute() == 0
 
     assert os.path.exists(
         os.path.join(tmp_trestle_dir, "system-security-plans", test_ssp_output)
     )
-
-
-def test_ssp_assemble_task_no_index_path(tmp_trestle_dir: str) -> None:
-    """Test ssp assemble at the task level with failure"""
-    trestle_root = pathlib.Path(tmp_trestle_dir)
-    md_path = os.path.join(ssp_md_dir, test_ssp_output)
-    args = testutils.setup_for_ssp(trestle_root, test_prof, [test_comp], md_path)
-    ssp_generate = SSPGenerate()
-    assert ssp_generate._run(args) == 0
-
-    assemble_task = AssembleTask(
-        tmp_trestle_dir,
-        AuthoredType.SSP.value,
-        ssp_md_dir,
-        "",
-    )
-    with pytest.raises(FileNotFoundError):
-        assemble_task.execute()

--- a/tests/trestlebot/tasks/test_regenerate_task.py
+++ b/tests/trestlebot/tasks/test_regenerate_task.py
@@ -26,7 +26,7 @@ import pytest
 from trestle.core.commands.author.ssp import SSPAssemble, SSPGenerate
 
 from tests import testutils
-from trestlebot.tasks.authored.base_authored import AuthorObjectBase
+from trestlebot.tasks.authored.base_authored import AuthoredObjectBase
 from trestlebot.tasks.authored.types import AuthoredType
 from trestlebot.tasks.base_task import ModelFilter
 from trestlebot.tasks.regenerate_task import RegenerateTask
@@ -49,7 +49,7 @@ def test_regenerate_task_isolated(tmp_trestle_dir: str) -> None:
     md_path = os.path.join(cat_md_dir, test_cat)
     _ = testutils.setup_for_catalog(trestle_root, test_cat, md_path)
 
-    mock = Mock(spec=AuthorObjectBase)
+    mock = Mock(spec=AuthoredObjectBase)
 
     regenerate_task = RegenerateTask(
         tmp_trestle_dir,
@@ -85,7 +85,7 @@ def test_regenerate_task_with_skip(tmp_trestle_dir: str, skip_list: List[str]) -
     md_path = os.path.join(cat_md_dir, test_cat)
     _ = testutils.setup_for_catalog(trestle_root, test_cat, md_path)
 
-    mock = Mock(spec=AuthorObjectBase)
+    mock = Mock(spec=AuthoredObjectBase)
 
     model_filter = ModelFilter(skip_list, ["*"])
 

--- a/tests/workflows/test_rules_transform_workflow.py
+++ b/tests/workflows/test_rules_transform_workflow.py
@@ -26,7 +26,6 @@ import trestlebot.const as const
 from tests.testutils import setup_for_profile
 from trestlebot.tasks.assemble_task import AssembleTask
 from trestlebot.tasks.authored.compdef import AuthoredComponentDefinition
-from trestlebot.tasks.authored.types import AuthoredType
 from trestlebot.tasks.regenerate_task import RegenerateTask
 from trestlebot.tasks.rule_transform_task import RuleTransformTask
 from trestlebot.transformers.yaml_transformer import ToRulesYAMLTransformer
@@ -82,9 +81,7 @@ def test_rules_transform_workflow(tmp_trestle_dir: str) -> None:
     last_modified = compdef.metadata.last_modified
 
     # Run regenerate
-    regenerate = RegenerateTask(
-        tmp_trestle_dir, AuthoredType.COMPDEF.value, test_md_path
-    )
+    regenerate = RegenerateTask(authored_compdef, test_md_path)
     regenerate.execute()
 
     assert os.path.exists(
@@ -92,7 +89,7 @@ def test_rules_transform_workflow(tmp_trestle_dir: str) -> None:
     )
 
     # Run assemble
-    assemble = AssembleTask(tmp_trestle_dir, AuthoredType.COMPDEF.value, test_md_path)
+    assemble = AssembleTask(authored_compdef, test_md_path)
     assemble.execute()
 
     # Load the component definition

--- a/trestlebot/entrypoints/autosync.py
+++ b/trestlebot/entrypoints/autosync.py
@@ -90,69 +90,67 @@ class AutoSyncEntrypoint(EntrypointBase):
             help="Path to ssp index file",
         )
 
+    def validate_args(self, args: argparse.Namespace) -> None:
+        """Validate the arguments for the autosync entrypoint."""
+        authored_list: List[str] = [model.value for model in types.AuthoredType]
+        if args.oscal_model not in authored_list:
+            logger.error(
+                f"Invalid value {args.oscal_model} for oscal model. "
+                f"Please use one of {authored_list}"
+            )
+            sys.exit(const.ERROR_EXIT_CODE)
+
+        if not args.markdown_path:
+            logger.error("Must set markdown path with oscal model.")
+            sys.exit(const.ERROR_EXIT_CODE)
+
+        if (
+            args.oscal_model == types.AuthoredType.SSP.value
+            and args.ssp_index_path == ""
+        ):
+            logger.error("Must set ssp_index_path when using SSP as oscal model.")
+            sys.exit(const.ERROR_EXIT_CODE)
+
     def run(self, args: argparse.Namespace) -> None:
         """Run the autosync entrypoint."""
 
         set_log_level_from_args(args)
+        self.validate_args(args)
 
         pre_tasks: List[TaskBase] = []
+        # Allow any model to be skipped from the args, by default include all
+        model_filter: ModelFilter = ModelFilter(
+            skip_patterns=comma_sep_to_list(args.skip_items),
+            include_patterns=["*"],
+        )
 
-        authored_list: List[str] = [model.value for model in types.AuthoredType]
+        authored_object = types.get_authored_object(
+            args.oscal_model, args.working_dir, args.ssp_index_path
+        )
 
-        # Pre-process flags
-
-        if args.oscal_model:
-            if args.oscal_model not in authored_list:
-                logger.error(
-                    f"Invalid value {args.oscal_model} for oscal model. "
-                    f"Please use one of {authored_list}"
-                )
-                sys.exit(const.ERROR_EXIT_CODE)
-
-            if not args.markdown_path:
-                logger.error("Must set markdown path with oscal model.")
-                sys.exit(const.ERROR_EXIT_CODE)
-
-            if (
-                args.oscal_model == types.AuthoredType.SSP.value
-                and args.ssp_index_path == ""
-            ):
-                logger.error("Must set ssp_index_path when using SSP as oscal model.")
-                sys.exit(const.ERROR_EXIT_CODE)
-
-            # Allow any model to be skipped from the args, by default include all
-            model_filter: ModelFilter = ModelFilter(
-                skip_patterns=comma_sep_to_list(args.skip_items),
-                include_patterns=["*"],
+        # Assuming an edit has occurred assemble would be run before regenerate.
+        # Adding this to the list first
+        if not args.skip_assemble:
+            assemble_task = AssembleTask(
+                authored_object=authored_object,
+                markdown_dir=args.markdown_path,
+                model_filter=model_filter,
             )
+            pre_tasks.append(assemble_task)
+        else:
+            logger.info("Assemble task skipped.")
 
-            # Assuming an edit has occurred assemble would be run before regenerate.
-            # Adding this to the list first
-            if not args.skip_assemble:
-                assemble_task = AssembleTask(
-                    working_dir=args.working_dir,
-                    authored_model=args.oscal_model,
-                    markdown_dir=args.markdown_path,
-                    ssp_index_path=args.ssp_index_path,
-                    model_filter=model_filter,
-                )
-                pre_tasks.append(assemble_task)
-            else:
-                logger.info("Assemble task skipped.")
+        if not args.skip_regenerate:
+            regenerate_task = RegenerateTask(
+                authored_object=authored_object,
+                markdown_dir=args.markdown_path,
+                model_filter=model_filter,
+            )
+            pre_tasks.append(regenerate_task)
+        else:
+            logger.info("Regeneration task skipped.")
 
-            if not args.skip_regenerate:
-                regenerate_task = RegenerateTask(
-                    working_dir=args.working_dir,
-                    authored_model=args.oscal_model,
-                    markdown_dir=args.markdown_path,
-                    ssp_index_path=args.ssp_index_path,
-                    model_filter=model_filter,
-                )
-                pre_tasks.append(regenerate_task)
-            else:
-                logger.info("Regeneration task skipped.")
-
-            super().run_base(args, pre_tasks)
+        super().run_base(args, pre_tasks)
 
 
 def main() -> None:

--- a/trestlebot/entrypoints/create_cd.py
+++ b/trestlebot/entrypoints/create_cd.py
@@ -33,7 +33,6 @@ from trestlebot.tasks.authored.compdef import (
     AuthoredComponentDefinition,
     FilterByProfile,
 )
-from trestlebot.tasks.authored.types import AuthoredType
 from trestlebot.tasks.base_task import ModelFilter, TaskBase
 from trestlebot.tasks.regenerate_task import RegenerateTask
 from trestlebot.tasks.rule_transform_task import RuleTransformTask
@@ -128,8 +127,7 @@ class CreateCDEntrypoint(EntrypointBase):
         pre_tasks.append(rule_transform_task)
 
         regenerate_task = RegenerateTask(
-            working_dir=args.working_dir,
-            authored_model=AuthoredType.COMPDEF.value,
+            authored_object=authored_comp,
             markdown_dir=args.markdown_path,
             model_filter=model_filter,
         )

--- a/trestlebot/tasks/assemble_task.py
+++ b/trestlebot/tasks/assemble_task.py
@@ -23,8 +23,8 @@ from typing import Optional
 from trestlebot import const
 from trestlebot.tasks.authored import types
 from trestlebot.tasks.authored.base_authored import (
+    AuthoredObjectBase,
     AuthoredObjectException,
-    AuthorObjectBase,
 )
 from trestlebot.tasks.base_task import ModelFilter, TaskBase, TaskException
 
@@ -70,7 +70,7 @@ class AssembleTask(TaskBase):
         Returns:
           0 on success, raises an exception if not successful
         """
-        authored_object: AuthorObjectBase = types.get_authored_object(
+        authored_object: AuthoredObjectBase = types.get_authored_object(
             self._authored_model, self.working_dir, self._ssp_index_path
         )
         search_path = os.path.join(self.working_dir, self._markdown_dir)

--- a/trestlebot/tasks/assemble_task.py
+++ b/trestlebot/tasks/assemble_task.py
@@ -21,7 +21,6 @@ import pathlib
 from typing import Optional
 
 from trestlebot import const
-from trestlebot.tasks.authored import types
 from trestlebot.tasks.authored.base_authored import (
     AuthoredObjectBase,
     AuthoredObjectException,
@@ -36,27 +35,25 @@ class AssembleTask(TaskBase):
 
     def __init__(
         self,
-        working_dir: str,
-        authored_model: str,
+        authored_object: AuthoredObjectBase,
         markdown_dir: str,
-        ssp_index_path: str = "",
+        version: str = "",
         model_filter: Optional[ModelFilter] = None,
     ) -> None:
         """
         Initialize assemble task.
 
         Args:
-            working_dir: Working directory to complete operations in
-            authored_model: String representation of model type
+            authored_object: Object can assembled OSCAL content into JSON
             markdown_dir: Location of directory to write Markdown in
-            ssp_index_path: Path of ssp index JSON in the workspace
             model_filter: Optional filter to apply to the task to include or exclude models
             from processing
         """
 
-        self._authored_model = authored_model
+        self._authored_object = authored_object
         self._markdown_dir = markdown_dir
-        self._ssp_index_path = ssp_index_path
+        self._version = version
+        working_dir = self._authored_object.get_trestle_root()
         super().__init__(working_dir, model_filter)
 
     def execute(self) -> int:
@@ -70,9 +67,6 @@ class AssembleTask(TaskBase):
         Returns:
           0 on success, raises an exception if not successful
         """
-        authored_object: AuthoredObjectBase = types.get_authored_object(
-            self._authored_model, self.working_dir, self._ssp_index_path
-        )
         search_path = os.path.join(self.working_dir, self._markdown_dir)
         for model in self.iterate_models(pathlib.Path(search_path)):
             # Construct model path from markdown path. AuthoredObject already has
@@ -80,7 +74,9 @@ class AssembleTask(TaskBase):
             model_base_name = os.path.basename(model)
             model_path = os.path.join(self._markdown_dir, model_base_name)
             try:
-                authored_object.assemble(markdown_path=model_path)
+                self._authored_object.assemble(
+                    markdown_path=model_path, version_tag=self._version
+                )
             except AuthoredObjectException as e:
                 raise TaskException(f"Assemble task failed for model {model_path}: {e}")
 

--- a/trestlebot/tasks/authored/base_authored.py
+++ b/trestlebot/tasks/authored/base_authored.py
@@ -23,7 +23,7 @@ class AuthoredObjectException(Exception):
     """An error during object authoring"""
 
 
-class AuthorObjectBase(ABC):
+class AuthoredObjectBase(ABC):
     """
     Abstract base class for OSCAL objects that are authored.
     """

--- a/trestlebot/tasks/authored/catalog.py
+++ b/trestlebot/tasks/authored/catalog.py
@@ -23,12 +23,12 @@ from trestle.common.err import TrestleError
 from trestle.core.repository import AgileAuthoring
 
 from trestlebot.tasks.authored.base_authored import (
+    AuthoredObjectBase,
     AuthoredObjectException,
-    AuthorObjectBase,
 )
 
 
-class AuthoredCatalog(AuthorObjectBase):
+class AuthoredCatalog(AuthoredObjectBase):
     """
     Class for authoring OSCAL catalogs in automation
     """

--- a/trestlebot/tasks/authored/compdef.py
+++ b/trestlebot/tasks/authored/compdef.py
@@ -30,8 +30,8 @@ from trestle.core.repository import AgileAuthoring
 
 from trestlebot.const import RULE_PREFIX, RULES_VIEW_DIR, YAML_EXTENSION
 from trestlebot.tasks.authored.base_authored import (
+    AuthoredObjectBase,
     AuthoredObjectException,
-    AuthorObjectBase,
 )
 from trestlebot.transformers.trestle_rule import (
     ComponentInfo,
@@ -66,7 +66,7 @@ class FilterByProfile:
         return control_id in self._control_ids
 
 
-class AuthoredComponentDefinition(AuthorObjectBase):
+class AuthoredComponentDefinition(AuthoredObjectBase):
     """
     Class for authoring OSCAL Component Definitions in automation
     """

--- a/trestlebot/tasks/authored/profile.py
+++ b/trestlebot/tasks/authored/profile.py
@@ -32,12 +32,12 @@ from trestle.core.repository import AgileAuthoring
 from trestle.oscal.common import IncludeAll
 
 from trestlebot.tasks.authored.base_authored import (
+    AuthoredObjectBase,
     AuthoredObjectException,
-    AuthorObjectBase,
 )
 
 
-class AuthoredProfile(AuthorObjectBase):
+class AuthoredProfile(AuthoredObjectBase):
     """
     Class for authoring OSCAL Profiles in automation
     """

--- a/trestlebot/tasks/authored/ssp.py
+++ b/trestlebot/tasks/authored/ssp.py
@@ -31,8 +31,8 @@ from trestle.oscal.component import ComponentDefinition
 
 from trestlebot.const import COMPDEF_KEY_NAME, LEVERAGED_SSP_KEY_NAME, PROFILE_KEY_NAME
 from trestlebot.tasks.authored.base_authored import (
+    AuthoredObjectBase,
     AuthoredObjectException,
-    AuthorObjectBase,
 )
 
 
@@ -149,7 +149,7 @@ class SSPIndex:
             json.dump(data, file, indent=4)
 
 
-class AuthoredSSP(AuthorObjectBase):
+class AuthoredSSP(AuthoredObjectBase):
     """
     Class for authoring OSCAL SSPs in automation
     """

--- a/trestlebot/tasks/authored/types.py
+++ b/trestlebot/tasks/authored/types.py
@@ -21,8 +21,8 @@ from enum import Enum
 from trestle.common import const
 
 from trestlebot.tasks.authored.base_authored import (
+    AuthoredObjectBase,
     AuthoredObjectException,
-    AuthorObjectBase,
 )
 from trestlebot.tasks.authored.catalog import AuthoredCatalog
 from trestlebot.tasks.authored.compdef import AuthoredComponentDefinition
@@ -41,7 +41,7 @@ class AuthoredType(Enum):
 
 def get_authored_object(
     input_type: str, working_dir: str, ssp_index_path: str = ""
-) -> AuthorObjectBase:
+) -> AuthoredObjectBase:
     """Determine and configure author object context"""
     if input_type == AuthoredType.CATALOG.value:
         return AuthoredCatalog(working_dir)

--- a/trestlebot/tasks/authored/types.py
+++ b/trestlebot/tasks/authored/types.py
@@ -56,15 +56,15 @@ def get_authored_object(
         raise AuthoredObjectException(f"Invalid authored type {input_type}")
 
 
-def get_trestle_model_dir(input_type: str) -> str:
+def get_trestle_model_dir(authored_object: AuthoredObjectBase) -> str:
     """Determine directory for JSON content in trestle"""
-    if input_type == AuthoredType.CATALOG.value:
+    if isinstance(authored_object, AuthoredCatalog):
         return const.MODEL_DIR_CATALOG
-    elif input_type == AuthoredType.PROFILE.value:
+    elif isinstance(authored_object, AuthoredProfile):
         return const.MODEL_DIR_PROFILE
-    elif input_type == AuthoredType.COMPDEF.value:
+    elif isinstance(authored_object, AuthoredComponentDefinition):
         return const.MODEL_DIR_COMPDEF
-    elif input_type == AuthoredType.SSP.value:
+    elif isinstance(authored_object, AuthoredSSP):
         return const.MODEL_DIR_SSP
     else:
-        raise AuthoredObjectException(f"Invalid authored type {input_type}")
+        raise AuthoredObjectException(f"Invalid authored object {authored_object}")

--- a/trestlebot/tasks/regenerate_task.py
+++ b/trestlebot/tasks/regenerate_task.py
@@ -23,8 +23,8 @@ from typing import Optional
 from trestlebot import const
 from trestlebot.tasks.authored import types
 from trestlebot.tasks.authored.base_authored import (
+    AuthoredObjectBase,
     AuthoredObjectException,
-    AuthorObjectBase,
 )
 from trestlebot.tasks.base_task import ModelFilter, TaskBase, TaskException
 
@@ -70,7 +70,7 @@ class RegenerateTask(TaskBase):
         Returns:
          0 on success, raises an exception if not successful
         """
-        authored_object: AuthorObjectBase = types.get_authored_object(
+        authored_object: AuthoredObjectBase = types.get_authored_object(
             self._authored_model, self.working_dir, self._ssp_index_path
         )
 


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

In some instances AuthoredObject types are used outside of the scope of tasks. Allowing the the tasks to directly take the AuthoredObject type allows these configured objects to be reused. It also decouples the task from the model specific AuthoredObject configuration.


## Type of change

<!--Please delete options that are not relevant.-->

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

*no end-user features added*

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Unit test updates/existing cover these changes 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
