### PR TITLE
test: adds negative tests to assemble and regenerate task tests

### DIFF
--- a/trestlebot/tasks/assemble_task.py
+++ b/trestlebot/tasks/assemble_task.py
@@ -68,6 +68,9 @@ class AssembleTask(TaskBase):
           0 on success, raises an exception if not successful
         """
         search_path = os.path.join(self.working_dir, self._markdown_dir)
+        if not os.path.exists(search_path):
+            raise TaskException(f"Markdown directory {search_path} does not exist")
+
         for model in self.iterate_models(pathlib.Path(search_path)):
             # Construct model path from markdown path. AuthoredObject already has
             # the working dir data as part of object construction.


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

- Adds tests to `test_assemble_task.py` and `test_regenerate_task.py` for failure/negative testing.
- Add check and test to ensure the markdown directory exists in the assemble task


Stacked/Incorporates #98 in response to PR feedback.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Adds tests

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Unit tests added

## Checklist

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
