### PR TITLE
ci: allows no-cache option for image building to ensure updated deps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,11 @@ on:
         type: boolean
         required: false
         default: false
+      no_cache:
+        description: "Skip using cache when building the image."
+        type: boolean
+        required: false
+        default: false
 env:
     IMAGE_NAME: trestle-bot
     IMAGE_REGISTRY: quay.io
@@ -25,14 +30,11 @@ jobs:
     permissions:
       contents: read
     outputs:
-      skip_tests: ${{ steps.check_event.outputs.event_type == 'release'
-                    || (steps.check_event.outputs.event_type == 'workflow_dispatch'
-                      && github.event.inputs.skip_tests == 'true') }}
+      skip_tests: ${{ steps.check_event.outputs.event_type == 'release' ||
+                  (steps.check_event.outputs.event_type == 'workflow_dispatch' &&
+                  github.event.inputs.skip_tests == 'true') }}
       image: ${{ env.IMAGE_REGISTRY }}/${{ vars.QUAY_ORG }}/${{ env.IMAGE_NAME }}@${{ steps.build-image.outputs.digest }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -53,20 +55,28 @@ jobs:
       # Using intermediary variable to process event based input
       - name: Set TAG environment variable for Release
         if: ${{ steps.check_event.outputs.event_type == 'release' }}
-        run: echo "TAG=$RELEASE_VERSION" >> "$GITHUB_ENV"
+        run: |
+          echo "TAG=$RELEASE_VERSION" >> "$GITHUB_ENV"
+          echo "NO_CACHE=true" >> "$GITHUB_ENV"
         env:
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Set TAG environment variable for Workflow Dispatch
         if: ${{ steps.check_event.outputs.event_type == 'workflow_dispatch' }}
-        run: echo "TAG=$INPUT_VERSION" >> "$GITHUB_ENV"
+        run: |
+           echo "TAG=$INPUT_VERSION" >> "$GITHUB_ENV"
+           echo "NO_CACHE=$INPUT_NO_CACHE" >> "$GITHUB_ENV"
         env:
           INPUT_VERSION: ${{ github.event.inputs.tag }}
+          INPUT_NO_CACHE: ${{ github.event.inputs.no_cache }}
       
       - name: Build and export to Docker
         uses: docker/build-push-action@v5
         with:
           load: true
+          no-cache: ${{ env.NO_CACHE == 'true' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ env.IMAGE_REGISTRY }}/${{ vars.QUAY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
       
       - name: Pre-push Image Scan
@@ -77,13 +87,12 @@ jobs:
           scanners: secret
           severity: HIGH,CRITICAL,MEDIUM
 
+      # Does not rebuild. Uses internal cache from previous step.
       - name: Build and Push
         uses: docker/build-push-action@v5
         id: build-image
         with:
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           tags: ${{ env.IMAGE_REGISTRY }}/${{ vars.QUAY_ORG }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
 
   test:


### PR DESCRIPTION
## Description

Make the using cache optional when using `workflow dispatch` and disable the use of it when creating the releases to ensure the we don't experience stale builds or miss out on required updates.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

- [X] Tested manually - https://github.com/jpower432/trestle-bot/actions/runs/7146238147/job/19463529408

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
