### PR TITLE
chore(deps): bumps the default poetry version used in image and the environment to 1.7.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/fedora/fedora:37
 
-ARG POETRY_VERSION=1.5.1
+ARG POETRY_VERSION=1.7.1
 
 RUN dnf -y update && \
     yum -y reinstall shadow-utils && \

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -5,7 +5,7 @@ inputs:
   poetry-version:
     required: false
     description: "The poetry version to use"
-    default: "1.5.1"
+    default: "1.7.1"
   python-version:
      required: false
      description: "The python version to use"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN microdnf update -y \
 
 FROM python-base AS dependencies
 
-ARG POETRY_VERSION=1.5.1
+ARG POETRY_VERSION=1.7.1
 
 # https://python-poetry.org/docs/configuration/#using-environment-variables
 ENV POETRY_HOME="/opt/poetry" \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ pre-commit:
 	@poetry run pre-commit install
 
 lint:
-	@poetry lock --check
+	@poetry check --lock
 	@poetry run isort --profile=black --lines-after-imports=2 \
 	--check-only $(TESTS) $(PYMODULE)
 	@poetry run black --check $(TESTS) $(PYMODULE) --diff


### PR DESCRIPTION
## Description

Updates poetry from 1.5.1 to 1.7.1

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Updates deps

## How has this been tested?

- Tested with Codespaces
- Tested image E2E/CI - https://github.com/jpower432/trestle-bot/actions/runs/7401558662/job/20137879875

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
