### PR TITLE
fix: updates language for linting pre-commit to system

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - repo: local
     hooks:
       - id: lint
-        language: script
+        language: system
         name: Check formatting and lint
         entry: make lint
         stages: [commit]


### PR DESCRIPTION
## Description

Bug found when changes to a python file are made. The language on the local pre-commit should be `system` not `script`.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Checked with a commit that modified a python file.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
