### PR TITLE
PSCE-321-P1: Adds yaml header path to ssp index

### DIFF
--- a/tests/data/json/invalid_test_ssp_index.json
+++ b/tests/data/json/invalid_test_ssp_index.json
@@ -1,0 +1,6 @@
+{
+    "ssp-name":
+    {
+        "profile": "profile"
+    }
+}

--- a/tests/data/json/test_ssp_index.json
+++ b/tests/data/json/test_ssp_index.json
@@ -5,6 +5,7 @@
         "component_definitions": [
             "comp-a"
         ],
-        "leveraged_ssp": "ssp-name"
+        "leveraged_ssp": "leveraged-ssp-name",
+        "yaml_header_path": "ssp-name.yaml"
     }
 }

--- a/tests/data/json/test_ssp_index.json
+++ b/tests/data/json/test_ssp_index.json
@@ -1,0 +1,10 @@
+{
+    "ssp-name":
+    {
+        "profile": "profile",
+        "component_definitions": [
+            "comp-a"
+        ],
+        "leveraged_ssp": "ssp-name"
+    }
+}

--- a/tests/data/yaml/extra_yaml_header.yaml
+++ b/tests/data/yaml/extra_yaml_header.yaml
@@ -1,0 +1,8 @@
+x-trestle-evidence:
+  named-evidence: location
+x-trestle-dependent-on:
+  - control-id:
+    profile:
+reviewed-by:
+  - named:
+    date:

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -27,6 +27,7 @@ from trestlebot.const import YAML_EXTENSION
 JSON_TEST_DATA_PATH = pathlib.Path("tests/data/json/").resolve()
 YAML_TEST_DATA_PATH = pathlib.Path("tests/data/yaml/").resolve()
 TEST_SSP_INDEX = JSON_TEST_DATA_PATH / "test_ssp_index.json"
+INVALID_TEST_SSP_INDEX = JSON_TEST_DATA_PATH / "invalid_test_ssp_index.json"
 
 # E2E test constants
 TRESTLEBOT_TEST_IMAGE_NAME = "localhost/trestlebot:latest"

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -5,7 +5,6 @@
 """Helper functions for unit test setup and teardown."""
 
 import argparse
-import json
 import pathlib
 import shutil
 import subprocess
@@ -22,16 +21,12 @@ from trestle.oscal import catalog as cat
 from trestle.oscal import component as comp
 from trestle.oscal import profile as prof
 
-from trestlebot.const import (
-    COMPDEF_KEY_NAME,
-    LEVERAGED_SSP_KEY_NAME,
-    PROFILE_KEY_NAME,
-    YAML_EXTENSION,
-)
+from trestlebot.const import YAML_EXTENSION
 
 
 JSON_TEST_DATA_PATH = pathlib.Path("tests/data/json/").resolve()
 YAML_TEST_DATA_PATH = pathlib.Path("tests/data/yaml/").resolve()
+TEST_SSP_INDEX = JSON_TEST_DATA_PATH / "test_ssp_index.json"
 
 # E2E test constants
 TRESTLEBOT_TEST_IMAGE_NAME = "localhost/trestlebot:latest"
@@ -265,25 +260,6 @@ def setup_rules_view(
         load_from_yaml(comp_dir, "test_complete_rule")
         # Load a complete rule with only required fields
         load_from_yaml(comp_dir, "test_complete_rule_no_params")
-
-
-def write_index_json(
-    file_path: str,
-    ssp_name: str,
-    profile: str,
-    component_definitions: List[str],
-    leveraged_ssp: str = "",
-) -> None:
-    """Write out ssp index JSON for tests"""
-    data = {
-        ssp_name: {PROFILE_KEY_NAME: profile, COMPDEF_KEY_NAME: component_definitions}
-    }
-
-    if leveraged_ssp:
-        data[ssp_name][LEVERAGED_SSP_KEY_NAME] = leveraged_ssp
-
-    with open(file_path, "w") as file:
-        json.dump(data, file, indent=4)
 
 
 def replace_string_in_file(file_path: str, old_string: str, new_string: str) -> None:

--- a/tests/trestlebot/tasks/authored/test_ssp.py
+++ b/tests/trestlebot/tasks/authored/test_ssp.py
@@ -236,6 +236,22 @@ def test_reload(tmp_trestle_dir: str) -> None:
         ssp_index.get_profile_by_ssp("new_ssp")
 
 
+def test_invalid_ssp_index(tmp_trestle_dir: str) -> None:
+    """Test to trigger failure for invalid SSP index"""
+    ssp_index_path = os.path.join(tmp_trestle_dir, "ssp-index.json")
+    ssp_index: SSPIndex = SSPIndex(ssp_index_path)
+
+    # Copy over a new index
+    shutil.copy2(testutils.INVALID_TEST_SSP_INDEX, ssp_index_path)
+
+    # Reread the ssp index from JSON
+    with pytest.raises(
+        AuthoredObjectException,
+        match="SSP .* entry is missing profile or component data",
+    ):
+        ssp_index.reload()
+
+
 def test_create_new_with_filter(tmp_trestle_dir: str) -> None:
     """Test to create new SSP with filtering by profile"""
     # Prepare the workspace and input ssp

--- a/tests/trestlebot/tasks/authored/test_ssp.py
+++ b/tests/trestlebot/tasks/authored/test_ssp.py
@@ -217,6 +217,7 @@ def test_reload(tmp_trestle_dir: str) -> None:
     assert ssp_index.get_profile_by_ssp("new_ssp") == "test_prof"
     assert "my_comp" in ssp_index.get_comps_by_ssp("new_ssp")
     assert ssp_index.get_leveraged_by_ssp("new_ssp") is None
+    assert ssp_index.get_yaml_header_by_ssp("new_ssp") is None
 
     # Copy over a new index
     shutil.copy2(testutils.TEST_SSP_INDEX, ssp_index_path)

--- a/tests/trestlebot/tasks/authored/test_ssp.py
+++ b/tests/trestlebot/tasks/authored/test_ssp.py
@@ -155,6 +155,17 @@ def test_get_leveraged_ssp(tmp_trestle_dir: str) -> None:
     assert ssp_index.get_leveraged_by_ssp(test_ssp_output) == leveraged_ssp
 
 
+def test_get_yaml_header(tmp_trestle_dir: str) -> None:
+    """Test to get yaml header from index"""
+    ssp_index_path = os.path.join(tmp_trestle_dir, "ssp-index.json")
+    ssp_index: SSPIndex = SSPIndex(ssp_index_path)
+    ssp_index.add_new_ssp(
+        test_ssp_output, test_prof, [test_comp], extra_yaml_header="ssp-name.yaml"
+    )
+
+    assert ssp_index.get_yaml_header_by_ssp(test_ssp_output) == "ssp-name.yaml"
+
+
 def test_add_ssp_to_index(tmp_trestle_dir: str) -> None:
     """Test adding an ssp to an index."""
     ssp_index_path = os.path.join(tmp_trestle_dir, "ssp-index.json")
@@ -210,8 +221,15 @@ def test_reload(tmp_trestle_dir: str) -> None:
     # Copy over a new index
     shutil.copy2(testutils.TEST_SSP_INDEX, ssp_index_path)
 
-    # Reread the ssp index from JSON and make sure the new ssp is not there
+    # Reread the ssp index from JSON
     ssp_index.reload()
+
+    assert ssp_index.get_profile_by_ssp("ssp-name") == "profile"
+    assert "comp-a" in ssp_index.get_comps_by_ssp("ssp-name")
+    assert ssp_index.get_leveraged_by_ssp("ssp-name") == "leveraged-ssp-name"
+    assert ssp_index.get_yaml_header_by_ssp("ssp-name") == "ssp-name.yaml"
+
+    # Make sure the new ssp is not present in memory
     with pytest.raises(
         AuthoredObjectException, match="SSP new_ssp does not exists in the index"
     ):

--- a/tests/trestlebot/tasks/authored/test_types.py
+++ b/tests/trestlebot/tasks/authored/test_types.py
@@ -4,7 +4,6 @@
 
 """Test author types for Trestlebot"""
 
-import os
 from unittest.mock import Mock
 
 import pytest
@@ -39,7 +38,7 @@ def test_get_authored_catalog(tmp_trestle_dir: str) -> None:
 
 
 def test_get_authored_profile(tmp_trestle_dir: str) -> None:
-    """Test get authored type for catalogs"""
+    """Test get authored type for profiles"""
 
     authored_object: AuthoredObjectBase = types.get_authored_object(
         types.AuthoredType.PROFILE.value, tmp_trestle_dir, ""
@@ -50,9 +49,8 @@ def test_get_authored_profile(tmp_trestle_dir: str) -> None:
 
 
 def test_get_authored_compdef(tmp_trestle_dir: str) -> None:
-    """Test get authored type for catalogs"""
+    """Test get authored type for compdefs"""
 
-    # Test with profile
     authored_object: AuthoredObjectBase = types.get_authored_object(
         types.AuthoredType.COMPDEF.value, tmp_trestle_dir, ""
     )
@@ -62,18 +60,15 @@ def test_get_authored_compdef(tmp_trestle_dir: str) -> None:
 
 
 def test_get_authored_ssp(tmp_trestle_dir: str) -> None:
-    """Test get authored type for catalogs"""
-    ssp_index_path = os.path.join(tmp_trestle_dir, "ssp-index.json")
-    testutils.write_index_json(ssp_index_path, test_ssp_output, test_prof, [test_comp])
-
+    """Test get authored type for ssp"""
     with pytest.raises(
         FileNotFoundError,
     ):
         _ = types.get_authored_object(types.AuthoredType.SSP.value, tmp_trestle_dir, "")
 
-    # Test with profile
+    # Test with a valid ssp index
     authored_object: AuthoredObjectBase = types.get_authored_object(
-        types.AuthoredType.SSP.value, tmp_trestle_dir, ssp_index_path
+        types.AuthoredType.SSP.value, tmp_trestle_dir, str(testutils.TEST_SSP_INDEX)
     )
 
     assert authored_object.get_trestle_root() == tmp_trestle_dir

--- a/tests/trestlebot/tasks/test_assemble_task.py
+++ b/tests/trestlebot/tasks/test_assemble_task.py
@@ -226,18 +226,17 @@ def test_compdef_assemble_task(tmp_trestle_dir: str) -> None:
 def test_ssp_assemble_task(tmp_trestle_dir: str, write_ssp_index: bool) -> None:
     """Test ssp assemble at the task level with and without an index"""
     ssp_index_path = os.path.join(tmp_trestle_dir, "ssp-index.json")
+    ssp_index = SSPIndex(ssp_index_path)
+
     if write_ssp_index:
-        testutils.write_index_json(
-            ssp_index_path, test_ssp_output, test_prof, [test_comp]
-        )
+        ssp_index.add_new_ssp(test_ssp_output, test_prof, [test_comp])
+        ssp_index.write_out()
 
     trestle_root = pathlib.Path(tmp_trestle_dir)
     md_path = os.path.join(ssp_md_dir, test_ssp_output)
     args = testutils.setup_for_ssp(trestle_root, test_prof, [test_comp], md_path)
     ssp_generate = SSPGenerate()
     assert ssp_generate._run(args) == 0
-
-    ssp_index = SSPIndex(ssp_index_path)
 
     ssp = AuthoredSSP(tmp_trestle_dir, ssp_index)
     assemble_task = AssembleTask(ssp, ssp_md_dir)

--- a/tests/trestlebot/tasks/test_regenerate_task.py
+++ b/tests/trestlebot/tasks/test_regenerate_task.py
@@ -162,10 +162,10 @@ def test_compdef_regenerate_task(tmp_trestle_dir: str) -> None:
 def test_ssp_regenerate_task(tmp_trestle_dir: str, write_ssp_index: bool) -> None:
     """Test ssp regenerate at the task level with and without an index"""
     ssp_index_path = os.path.join(tmp_trestle_dir, "ssp-index.json")
+    ssp_index = SSPIndex(ssp_index_path)
     if write_ssp_index:
-        testutils.write_index_json(
-            ssp_index_path, test_ssp_output, test_prof, [test_comp]
-        )
+        ssp_index.add_new_ssp(test_ssp_output, test_prof, [test_comp])
+        ssp_index.write_out()
 
     trestle_root = pathlib.Path(tmp_trestle_dir)
     md_path = os.path.join(ssp_md_dir, test_ssp_output)
@@ -189,7 +189,6 @@ def test_ssp_regenerate_task(tmp_trestle_dir: str, write_ssp_index: bool) -> Non
     )
     assert ssp_assemble._run(args) == 0
 
-    ssp_index = SSPIndex(ssp_index_path)
     ssp = AuthoredSSP(tmp_trestle_dir, ssp_index)
     regenerate_task = RegenerateTask(ssp, ssp_md_dir)
 

--- a/trestlebot/const.py
+++ b/trestlebot/const.py
@@ -18,6 +18,7 @@ INVALID_ARGS_EXIT_CODE = 2
 PROFILE_KEY_NAME = "profile"
 COMPDEF_KEY_NAME = "component_definitions"
 LEVERAGED_SSP_KEY_NAME = "leveraged_ssp"
+YAML_HEADER_PATH_KEY_NAME = "yaml_header_path"
 
 # Rule YAML Fields
 RULE_INFO_TAG = trestle_const.TRESTLE_TAG + "rule-info"


### PR DESCRIPTION
## Description

Adds YAML header to the SSPIndex to use custom YAML headers with `ssp-generate`

### Additional Changes

Refactors the way ssp index writing is done in the unit test to prepare for this. Having another util function to write the index essentially does what the `SSPIndex` class does. To reduce the changes every time that class is change, using it to create ssp index files dynamically and using test data for other tests.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Unit tests

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
