### PR TITLE
PSCE-299: Adds create-ssp entrypoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,8 @@ make develop
 poetry run trestlebot-autosync
 poetry run trestlebot-rules-transform
 poetry run trestlebot-create-cd
+poetry run trestlebot-sync-upstreams
+poetry run trestlebot-create-ssp
 ```
 
 #### Local testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ trestlebot-autosync = "trestlebot.entrypoints.autosync:main"
 trestlebot-rules-transform = "trestlebot.entrypoints.rule_transform:main"
 trestlebot-create-cd = "trestlebot.entrypoints.create_cd:main"
 trestlebot-sync-upstreams = "trestlebot.entrypoints.sync_upstreams:main"
+trestlebot-create-ssp = "trestlebot.entrypoints.create_ssp:main"
 
 [tool.poetry.dependencies]
 python = '^3.8.1'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ def tmp_repo() -> YieldFixture[Tuple[str, Repo]]:
     with TemporaryDirectory(prefix=_TEST_PREFIX) as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         repo: Repo = repo_setup(tmp_path)
+        remote_url = "http://localhost:8080/test.git"
+        repo.create_remote("origin", url=remote_url)
         yield tmpdir, repo
 
         try:

--- a/tests/e2e/test_e2e_compdef.py
+++ b/tests/e2e/test_e2e_compdef.py
@@ -94,9 +94,6 @@ def test_rules_transform_e2e(
     # Setup the rules directory
     setup_rules_view(tmp_repo_path, test_comp_name)
 
-    remote_url = "http://localhost:8080/test.git"
-    repo.create_remote("origin", url=remote_url)
-
     command = build_test_command(
         tmp_repo_str, "rules-transform", command_args, image_name
     )
@@ -214,15 +211,12 @@ def test_create_cd_e2e(
 
     logger.info(f"Running test: {test_name}")
 
-    tmp_repo_str, repo = tmp_repo
+    tmp_repo_str, _ = tmp_repo
     tmp_repo_path = pathlib.Path(tmp_repo_str)
 
     # Load profiles into the environment
     _ = setup_for_profile(tmp_repo_path, test_prof, "")
     load_from_json(tmp_repo_path, test_filter_prof, test_filter_prof, Profile)
-
-    remote_url = "http://localhost:8080/test.git"
-    repo.create_remote("origin", url=remote_url)
 
     command = build_test_command(tmp_repo_str, "create-cd", command_args, image_name)
     run_response = subprocess.run(command, cwd=tmp_repo_path, capture_output=True)

--- a/tests/e2e/test_e2e_ssp.py
+++ b/tests/e2e/test_e2e_ssp.py
@@ -36,8 +36,8 @@ from tests.testutils import (
     prepare_upstream_repo,
     setup_for_ssp,
 )
-from trestlebot.const import ERROR_EXIT_CODE, INVALID_ARGS_EXIT_CODE, SUCCESS_EXIT_CODE
-from trestlebot.tasks.authored.ssp import AuthoredSSP, SSPIndex
+from trestlebot.const import ERROR_EXIT_CODE, SUCCESS_EXIT_CODE
+from trestlebot.tasks.authored.ssp import SSPIndex
 
 
 logger = logging.getLogger(__name__)
@@ -78,17 +78,6 @@ test_ssp_name = "test_ssp"
             ERROR_EXIT_CODE,
             True,
         ),
-        (
-            "failure/missing args",
-            {
-                "branch": "test",
-                "oscal-model": "ssp",
-                "committer-name": "test",
-                "committer-email": "test@email.com",
-            },
-            INVALID_ARGS_EXIT_CODE,
-            False,
-        ),
     ],
 )
 def test_ssp_editing_e2e(
@@ -111,32 +100,39 @@ def test_ssp_editing_e2e(
     tmp_repo_path = pathlib.Path(tmp_repo_str)
 
     args = setup_for_ssp(tmp_repo_path, test_prof, [test_comp_name], test_ssp_md)
+    remote_url = "http://localhost:8080/test.git"
+    repo.create_remote("origin", url=remote_url)
 
     # Create or generate the SSP
     if not skip_create:
-        index_path = os.path.join(tmp_repo_str, "ssp-index.json")
-        ssp_index = SSPIndex(index_path)
-        authored_ssp = AuthoredSSP(tmp_repo_str, ssp_index)
-        authored_ssp.create_new_default(
-            test_ssp_name,
-            test_prof,
-            [test_comp_name],
-            test_ssp_md,
+        create_args: Dict[str, str] = {
+            "markdown-path": command_args["markdown-path"],
+            "branch": command_args["branch"],
+            "committer-name": command_args["committer-name"],
+            "committer-email": command_args["committer-email"],
+            "ssp-name": test_ssp_name,
+            "profile-name": test_prof,
+            "compdefs": test_comp_name,
+        }
+        command = build_test_command(
+            tmp_repo_str, "create-ssp", create_args, image_name
         )
+        run_response = subprocess.run(command, capture_output=True)
+        assert run_response.returncode == response
+        assert (tmp_repo_path / command_args["markdown-path"]).exists()
+
+        # Make a change to the SSP
+        ssp, ssp_path = ModelUtils.load_model_for_class(
+            tmp_repo_path,
+            test_ssp_name,
+            SystemSecurityPlan,
+            FileContentType.JSON,
+        )
+        ssp.metadata.title = "New Title"
+        ssp.oscal_write(ssp_path)
     else:
         ssp_generate = SSPGenerate()
         assert ssp_generate._run(args) == 0
-
-    ssp_path: pathlib.Path = ModelUtils.get_model_path_for_name_and_class(
-        tmp_repo_path,
-        test_ssp_name,
-        SystemSecurityPlan,
-        FileContentType.JSON,
-    )
-    assert not ssp_path.exists()
-
-    remote_url = "http://localhost:8080/test.git"
-    repo.create_remote("origin", url=remote_url)
 
     command = build_test_command(tmp_repo_str, "autosync", command_args, image_name)
     run_response = subprocess.run(command, capture_output=True)
@@ -151,8 +147,8 @@ def test_ssp_editing_e2e(
         )
 
         # Check that the correct files are present with the correct content
-        assert (tmp_repo_path / command_args["markdown-path"]).exists()
-        ssp_index.reload()
+        index_path = os.path.join(tmp_repo_str, "ssp-index.json")
+        ssp_index = SSPIndex(index_path)
         assert ssp_index.get_profile_by_ssp(test_ssp_name) == test_prof
         assert ssp_index.get_comps_by_ssp(test_ssp_name) == [test_comp_name]
         assert ssp_index.get_leveraged_by_ssp(test_ssp_name) is None

--- a/tests/e2e/test_e2e_ssp.py
+++ b/tests/e2e/test_e2e_ssp.py
@@ -96,12 +96,10 @@ def test_ssp_editing_e2e(
 
     logger.info(f"Running test: {test_name}")
 
-    tmp_repo_str, repo = tmp_repo
+    tmp_repo_str, _ = tmp_repo
     tmp_repo_path = pathlib.Path(tmp_repo_str)
 
     args = setup_for_ssp(tmp_repo_path, test_prof, [test_comp_name], test_ssp_md)
-    remote_url = "http://localhost:8080/test.git"
-    repo.create_remote("origin", url=remote_url)
 
     # Create or generate the SSP
     if not skip_create:

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -39,6 +39,7 @@ CONTAINER_FILE_NAME = "Dockerfile"
 
 # Location the upstream repo is mounted to in the container
 UPSTREAM_REPO = "/upstream"
+TEST_REMOTE_REPO_URL = "http://localhost:8080/test.git"
 
 
 def clean(repo_path: str, repo: Optional[Repo]) -> None:

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -28,6 +28,7 @@ JSON_TEST_DATA_PATH = pathlib.Path("tests/data/json/").resolve()
 YAML_TEST_DATA_PATH = pathlib.Path("tests/data/yaml/").resolve()
 TEST_SSP_INDEX = JSON_TEST_DATA_PATH / "test_ssp_index.json"
 INVALID_TEST_SSP_INDEX = JSON_TEST_DATA_PATH / "invalid_test_ssp_index.json"
+TEST_YAML_HEADER = YAML_TEST_DATA_PATH / "extra_yaml_header.yaml"
 
 # E2E test constants
 TRESTLEBOT_TEST_IMAGE_NAME = "localhost/trestlebot:latest"

--- a/tests/trestlebot/entrypoints/test_create_ssp.py
+++ b/tests/trestlebot/entrypoints/test_create_ssp.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 Red Hat, Inc.
+
+
+"""Test for Create SSP CLI"""
+
+import logging
+import pathlib
+from typing import Any, Dict, Tuple
+from unittest.mock import patch
+
+import pytest
+from git import Repo
+
+from tests.testutils import TEST_YAML_HEADER, args_dict_to_list, setup_for_ssp
+from trestlebot.entrypoints.create_ssp import main as cli_main
+
+
+@pytest.fixture
+def base_args_dict() -> Dict[str, str]:
+    return {
+        "branch": "main",
+        "committer-name": "test",
+        "profile-name": "simplified_nist_profile",
+        "ssp-name": "test-ssp",
+        "committer-email": "test@email.com",
+        "working-dir": ".",
+        "file-patterns": ".",
+    }
+
+
+test_cat = "simplified_nist_catalog"
+test_prof = "simplified_nist_profile"
+test_comp_name = "test_comp"
+test_ssp_md = "md_ssp"
+test_repo_url = "git.test.com/test/repo.git"
+
+# Expecting more md files to be included in the commit
+# but checking that the md directory was created and the ssp-index.json was created
+expected_files = [
+    "md_ssp/test-ssp/ac/ac-2.1.md",
+    "system-security-plans/test-ssp/system-security-plan.json",
+    "ssp-index.json",
+]
+
+
+def test_create_ssp(
+    tmp_repo: Tuple[str, Repo], base_args_dict: Dict[str, str], caplog: Any
+) -> None:
+    """Test create-ssp with valid args and a custom yaml header."""
+    repo_path, repo = tmp_repo
+    tmp_repo_path = pathlib.Path(repo_path)
+    repo.create_remote("origin", url=test_repo_url)
+
+    args_dict = base_args_dict
+    args_dict["working-dir"] = repo_path
+    args_dict["markdown-path"] = test_ssp_md
+    args_dict["compdefs"] = test_comp_name
+    args_dict["ssp-index-path"] = str(tmp_repo_path / "ssp-index.json")
+    args_dict["yaml-header-path"] = str(TEST_YAML_HEADER)
+
+    _ = setup_for_ssp(tmp_repo_path, test_prof, [test_comp_name], test_ssp_md)
+
+    with patch("git.remote.Remote.push") as mock_push, patch(
+        "sys.argv", ["trestlebot", *args_dict_to_list(args_dict)]
+    ):
+        mock_push.return_value = "Mocked Results"
+        with pytest.raises(SystemExit, match="0"):
+            cli_main()
+
+    # Verify that the correct files were included
+    commit = next(repo.iter_commits())
+    assert all(file in commit.stats.files for file in expected_files)
+    assert len(commit.stats.files) == 17
+
+    assert any(
+        record.levelno == logging.INFO
+        and "Changes pushed to main successfully" in record.message
+        for record in caplog.records
+    )

--- a/tests/trestlebot/entrypoints/test_create_ssp.py
+++ b/tests/trestlebot/entrypoints/test_create_ssp.py
@@ -33,7 +33,6 @@ test_cat = "simplified_nist_catalog"
 test_prof = "simplified_nist_profile"
 test_comp_name = "test_comp"
 test_ssp_md = "md_ssp"
-test_repo_url = "git.test.com/test/repo.git"
 
 # Expecting more md files to be included in the commit
 # but checking that the md directory was created and the ssp-index.json was created
@@ -50,7 +49,6 @@ def test_create_ssp(
     """Test create-ssp with valid args and a custom yaml header."""
     repo_path, repo = tmp_repo
     tmp_repo_path = pathlib.Path(repo_path)
-    repo.create_remote("origin", url=test_repo_url)
 
     args_dict = base_args_dict
     args_dict["working-dir"] = repo_path
@@ -86,7 +84,6 @@ def test_create_ssp_with_error(
     """Test create-ssp and trigger an error."""
     repo_path, repo = tmp_repo
     tmp_repo_path = pathlib.Path(repo_path)
-    repo.create_remote("origin", url=test_repo_url)
 
     args_dict = base_args_dict
     args_dict["working-dir"] = repo_path

--- a/tests/trestlebot/entrypoints/test_create_ssp.py
+++ b/tests/trestlebot/entrypoints/test_create_ssp.py
@@ -101,11 +101,9 @@ def test_create_ssp_with_error(
         with pytest.raises(SystemExit, match="1"):
             cli_main()
 
-    # This error message occur when trestlebot fails. We are calling
-    # the trestlebot CLI directly so specific error will be logged separately
     assert any(
         record.levelno == logging.ERROR
-        and "Exception occurred during execution: Unknown error "
-        "occurred while regenerating test-ssp" in record.message
+        and "Component Definition fake_comp_name does not exist in the workspace"
+        in record.message
         for record in caplog.records
     )

--- a/tests/trestlebot/entrypoints/test_sync_upstreams.py
+++ b/tests/trestlebot/entrypoints/test_sync_upstreams.py
@@ -31,7 +31,6 @@ test_cat = "simplified_nist_catalog"
 test_cat_path = "catalogs/simplified_nist_catalog/catalog.json"
 test_prof = "simplified_nist_profile"
 test_prof_path = "profiles/simplified_nist_profile/profile.json"
-test_repo_url = "git.test.com/test/repo.git"
 
 
 def test_sync_upstreams(
@@ -39,7 +38,6 @@ def test_sync_upstreams(
 ) -> None:
     """Test sync upstreams with default settings and valid args."""
     repo_path, repo = tmp_repo
-    repo.create_remote("origin", url=test_repo_url)
 
     args_dict = valid_args_dict
     args_dict["working-dir"] = repo_path
@@ -70,7 +68,6 @@ def test_with_include_model_names(
 ) -> None:
     """Test sync upstreams with include model names flag."""
     repo_path, repo = tmp_repo
-    repo.create_remote("origin", url=test_repo_url)
 
     args_dict = valid_args_dict
     args_dict["include-model-names"] = test_cat
@@ -101,7 +98,6 @@ def test_with_exclude_model_names(
 ) -> None:
     """Test sync upstreams with exclude model names flag."""
     repo_path, repo = tmp_repo
-    repo.create_remote("origin", url=test_repo_url)
 
     args_dict = valid_args_dict
     args_dict["exclude-model-names"] = test_prof

--- a/tests/trestlebot/tasks/authored/test_ssp.py
+++ b/tests/trestlebot/tasks/authored/test_ssp.py
@@ -253,6 +253,34 @@ def test_invalid_ssp_index(tmp_trestle_dir: str) -> None:
         ssp_index.reload()
 
 
+def test_create_new_default_with_errors(tmp_trestle_dir: str) -> None:
+    """Test to create new SSP and trigger failures for missing OSCAL files."""
+    # Prepare the workspace and input ssp
+    md_path = os.path.join(markdown_dir, test_ssp_output)
+    trestle_root = pathlib.Path(tmp_trestle_dir)
+    _ = testutils.setup_for_ssp(trestle_root, test_prof, [test_comp], md_path)
+
+    ssp_index_path = os.path.join(tmp_trestle_dir, "ssp-index.json")
+    ssp_index: SSPIndex = SSPIndex(ssp_index_path)
+
+    authored_ssp = AuthoredSSP(tmp_trestle_dir, ssp_index)
+
+    with pytest.raises(
+        AuthoredObjectException, match="Profile .* does not exist in the workspace"
+    ):
+        authored_ssp.create_new_default(
+            test_ssp_output, "fake_profile", [test_comp], md_path
+        )
+
+    with pytest.raises(
+        AuthoredObjectException,
+        match="Component Definition .* does not exist in the workspace",
+    ):
+        authored_ssp.create_new_default(
+            test_ssp_output, test_prof, ["fake_comp"], md_path
+        )
+
+
 def test_create_new_with_filter(tmp_trestle_dir: str) -> None:
     """Test to create new SSP with filtering by profile"""
     # Prepare the workspace and input ssp

--- a/tests/trestlebot/test_bot.py
+++ b/tests/trestlebot/test_bot.py
@@ -178,8 +178,6 @@ def test_run(tmp_repo: Tuple[str, Repo]) -> None:
     with open(test_file_path, "w") as f:
         f.write("Test content")
 
-    repo.create_remote("origin", url="git.test.com/test/repo.git")
-
     with patch("git.remote.Remote.push") as mock_push:
         mock_push.return_value = "Mocked result"
 
@@ -315,8 +313,6 @@ def test_run_with_exception(
     with open(test_file_path, "w") as f:
         f.write("Test content")
 
-    repo.create_remote("origin", url="git.test.com/test/repo.git")
-
     bot = TrestleBot(
         working_dir=repo_path,
         branch="main",
@@ -347,8 +343,6 @@ def test_run_with_failed_pre_task(tmp_repo: Tuple[str, Repo]) -> None:
     mock = Mock(spec=TaskBase)
     mock.execute.side_effect = TaskException("example")
 
-    repo.create_remote("origin", url="git.test.com/test/repo.git")
-
     bot = TrestleBot(
         working_dir=repo_path,
         branch="main",
@@ -377,8 +371,6 @@ def test_run_with_provider(tmp_repo: Tuple[str, Repo]) -> None:
     mock = Mock(spec=GitProvider)
     mock.create_pull_request.return_value = 10
     mock.parse_repository.return_value = ("ns", "repo")
-
-    repo.create_remote("origin", url="git.test.com/test/repo.git")
 
     bot = TrestleBot(
         working_dir=repo_path,
@@ -436,8 +428,6 @@ def test_run_with_provider_with_custom_pr_title(tmp_repo: Tuple[str, Repo]) -> N
     mock = Mock(spec=GitProvider)
     mock.create_pull_request.return_value = "10"
     mock.parse_repository.return_value = ("ns", "repo")
-
-    repo.create_remote("origin", url="git.test.com/test/repo.git")
 
     bot = TrestleBot(
         working_dir=repo_path,

--- a/tests/trestlebot/test_github.py
+++ b/tests/trestlebot/test_github.py
@@ -39,9 +39,7 @@ def test_parse_repository_integration(tmp_repo: Tuple[str, Repo]) -> None:
     """Tests integration with git remote get-url"""
     repo_path, repo = tmp_repo
 
-    repo.create_remote("origin", url="github.com/test/repo.git")
-
-    remote = repo.remote()
+    remote = repo.create_remote("test", url="github.com/test/repo.git")
 
     gh = GitHub("fake")
 

--- a/tests/trestlebot/test_gitlab.py
+++ b/tests/trestlebot/test_gitlab.py
@@ -76,9 +76,7 @@ def test_parse_repository_integration(tmp_repo: Tuple[str, Repo]) -> None:
     """Tests integration with git remote get-url"""
     repo_path, repo = tmp_repo
 
-    repo.create_remote("origin", url="gitlab.com/test/repo.git")
-
-    remote = repo.remote()
+    remote = repo.create_remote("test", url="gitlab.com/test/repo.git")
 
     gl = GitLab("fake")
 

--- a/trestlebot/entrypoints/create_ssp.py
+++ b/trestlebot/entrypoints/create_ssp.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024 Red Hat, Inc.
+
+"""
+Entrypoint for system security plan bootstrapping.
+
+This will create and initial SSP with markdown, an SSP index, and a SSP JSON file.
+"""
+
+import argparse
+import logging
+import pathlib
+import sys
+from typing import List
+
+from trestlebot.const import SUCCESS_EXIT_CODE
+from trestlebot.entrypoints.entrypoint_base import (
+    EntrypointBase,
+    comma_sep_to_list,
+    handle_exception,
+)
+from trestlebot.entrypoints.log import set_log_level_from_args
+from trestlebot.tasks.assemble_task import AssembleTask
+from trestlebot.tasks.authored.ssp import AuthoredSSP, SSPIndex
+from trestlebot.tasks.base_task import ModelFilter, TaskBase
+
+
+logger = logging.getLogger(__name__)
+
+
+class CreateSSPEntrypoint(EntrypointBase):
+    """Entrypoint for ssp bootstrapping."""
+
+    def __init__(self, parser: argparse.ArgumentParser) -> None:
+        """Initialize."""
+        super().__init__(parser)
+        self.setup_create_ssp_arguments()
+
+    def setup_create_ssp_arguments(self) -> None:
+        """Setup specific arguments for this entrypoint."""
+        self.parser.add_argument(
+            "--ssp-name", required=True, type=str, help="Name of SSP to create."
+        )
+        self.parser.add_argument(
+            "--profile-name",
+            required=True,
+            help="Name of profile in the trestle workspace to include in the SSP.",
+        )
+        self.parser.add_argument(
+            "--compdefs",
+            required=True,
+            type=str,
+            help="Comma-separated list of component definitions to include in the SSP",
+        )
+        self.parser.add_argument(
+            "--leveraged-ssp",
+            required=False,
+            type=str,
+            help="Provider SSP to leverage for the new SSP.",
+        )
+        self.parser.add_argument(
+            "--markdown-path",
+            required=True,
+            type=str,
+            help="Path to create markdown files in.",
+        )
+        self.parser.add_argument(
+            "--yaml-header-path",
+            required=False,
+            type=str,
+            help="Optionally set a path to a YAML file for custom SSP Markdown YAML headers.",
+        )
+        self.parser.add_argument(
+            "--version",
+            required=False,
+            type=str,
+            help="Optionally set the SSP version.",
+        )
+        self.parser.add_argument(
+            "--ssp-index-path",
+            required=False,
+            type=str,
+            default="ssp-index.json",
+            help="Optionally set the path to the SSP index file.",
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+        """Run the entrypoint."""
+        exit_code: int = SUCCESS_EXIT_CODE
+        try:
+            set_log_level_from_args(args)
+
+            # If the ssp index file does not exist, create it.
+            ssp_index_path = pathlib.Path(args.ssp_index_path)
+            if not ssp_index_path.exists():
+                # Create a parent directory
+                ssp_index_path.parent.mkdir(parents=True, exist_ok=True)
+
+            ssp_index = SSPIndex(args.ssp_index_path)
+            authored_ssp = AuthoredSSP(args.working_dir, ssp_index)
+
+            comps: List[str] = comma_sep_to_list(args.compdefs)
+            authored_ssp.create_new_default(
+                ssp_name=args.ssp_name,
+                profile_name=args.profile_name,
+                compdefs=comps,
+                markdown_path=args.markdown_path,
+                leveraged_ssp=args.leveraged_ssp,
+                yaml_header=args.yaml_header_path,
+            )
+
+            # The starting point for SSPs is the markdown, so assemble into JSON.
+            model_filter: ModelFilter = ModelFilter([], [args.ssp_name])
+            assemble_task = AssembleTask(
+                authored_object=authored_ssp,
+                markdown_dir=args.markdown_path,
+                version=args.version,
+                model_filter=model_filter,
+            )
+            pre_tasks: List[TaskBase] = [assemble_task]
+
+            super().run_base(args, pre_tasks)
+        except Exception as e:
+            exit_code = handle_exception(e)
+
+        sys.exit(exit_code)
+
+
+def main() -> None:
+    """Run the CLI."""
+    parser = argparse.ArgumentParser(
+        description="Create new system security plan for editing."
+    )
+    create_ssp = CreateSSPEntrypoint(parser=parser)
+
+    args = parser.parse_args()
+    create_ssp.run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/trestlebot/entrypoints/create_ssp.py
+++ b/trestlebot/entrypoints/create_ssp.py
@@ -92,11 +92,8 @@ class CreateSSPEntrypoint(EntrypointBase):
         try:
             set_log_level_from_args(args)
 
-            # If the ssp index file does not exist, create it.
             ssp_index_path = pathlib.Path(args.ssp_index_path)
-            if not ssp_index_path.exists():
-                # Create a parent directory
-                ssp_index_path.parent.mkdir(parents=True, exist_ok=True)
+            ssp_index_path.parent.mkdir(parents=True, exist_ok=True)
 
             ssp_index: SSPIndex = SSPIndex(args.ssp_index_path)
             authored_ssp: AuthoredSSP = AuthoredSSP(args.working_dir, ssp_index)

--- a/trestlebot/entrypoints/create_ssp.py
+++ b/trestlebot/entrypoints/create_ssp.py
@@ -98,8 +98,8 @@ class CreateSSPEntrypoint(EntrypointBase):
                 # Create a parent directory
                 ssp_index_path.parent.mkdir(parents=True, exist_ok=True)
 
-            ssp_index = SSPIndex(args.ssp_index_path)
-            authored_ssp = AuthoredSSP(args.working_dir, ssp_index)
+            ssp_index: SSPIndex = SSPIndex(args.ssp_index_path)
+            authored_ssp: AuthoredSSP = AuthoredSSP(args.working_dir, ssp_index)
 
             comps: List[str] = comma_sep_to_list(args.compdefs)
             authored_ssp.create_new_default(
@@ -113,7 +113,7 @@ class CreateSSPEntrypoint(EntrypointBase):
 
             # The starting point for SSPs is the markdown, so assemble into JSON.
             model_filter: ModelFilter = ModelFilter([], [args.ssp_name])
-            assemble_task = AssembleTask(
+            assemble_task: AssembleTask = AssembleTask(
                 authored_object=authored_ssp,
                 markdown_dir=args.markdown_path,
                 version=args.version,

--- a/trestlebot/tasks/authored/ssp.py
+++ b/trestlebot/tasks/authored/ssp.py
@@ -16,6 +16,7 @@ from trestle.core.commands.author.ssp import SSPFilter
 from trestle.core.commands.common.return_codes import CmdReturnCodes
 from trestle.core.repository import AgileAuthoring
 from trestle.oscal.component import ComponentDefinition
+from trestle.oscal.profile import Profile
 
 from trestlebot.const import (
     COMPDEF_KEY_NAME,
@@ -253,6 +254,26 @@ class AuthoredSSP(AuthoredObjectBase):
         Notes:
             This will generate SSP markdown and an index entry for a new managed SSP.
         """
+
+        # Verify that the profile and compdefs exist
+        trestle_root_str = self.get_trestle_root()
+        trestle_root = pathlib.Path(trestle_root_str)
+        profile_path = ModelUtils.get_model_path_for_name_and_class(
+            trestle_root, profile_name, Profile
+        )
+        if profile_path is None:
+            raise AuthoredObjectException(
+                f"Profile {profile_name} does not exist in the workspace."
+            )
+
+        for compdef in compdefs:
+            compdef_path = ModelUtils.get_model_path_for_name_and_class(
+                trestle_root, compdef, ComponentDefinition
+            )
+            if compdef_path is None:
+                raise AuthoredObjectException(
+                    f"Component Definition {compdef} does not exist in the workspace."
+                )
 
         self.ssp_index.add_new_ssp(
             ssp_name, profile_name, compdefs, leveraged_ssp, yaml_header


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Adds a create-ssp entrypoint for SSP bootstrapping 

Stacked with #157 

## Rationale

SSP creation is becoming more customized with
the addition of yaml header. Adding a `create-ssp` entrypoint will reduce error  when working with autosync command and SSPs.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] E2E tests updated
- [x] Unit tests

## Checklist

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
