### PR TITLE
feat: adds main_comp_only to create_new_with_filter in ssp.py

### DIFF
--- a/tests/trestlebot/tasks/authored/test_ssp.py
+++ b/tests/trestlebot/tasks/authored/test_ssp.py
@@ -315,13 +315,26 @@ def test_create_new_with_filter(tmp_trestle_dir: str) -> None:
     )
     assert model_path.exists()
 
-    assert len(ssp.system_implementation.components) == 1
+    assert len(ssp.system_implementation.components) == 2
 
     component_names = [
         component.title for component in ssp.system_implementation.components
     ]
     assert test_comp_2 in component_names
+    assert const.SSP_MAIN_COMP_NAME in component_names
     assert test_comp not in component_names
+
+    # Main comp only
+    authored_ssp.create_new_with_filter(ssp_name, input_ssp, main_comp_only=True)
+    ssp, model_path = load_validate_model_name(
+        trestle_root, ssp_name, ossp.SystemSecurityPlan, FileContentType.JSON
+    )
+    assert model_path.exists()
+
+    assert len(ssp.system_implementation.components) == 1
+    assert const.SSP_MAIN_COMP_NAME in [
+        component.title for component in ssp.system_implementation.components
+    ]
 
     # Check that the ssp_index is not updated
     ssp_name = "new_ssp_2"

--- a/trestlebot/tasks/authored/ssp.py
+++ b/trestlebot/tasks/authored/ssp.py
@@ -10,6 +10,7 @@ import os
 import pathlib
 from typing import Any, Dict, List, Optional
 
+from trestle.common.const import SSP_MAIN_COMP_NAME
 from trestle.common.err import TrestleError
 from trestle.common.model_utils import ModelUtils
 from trestle.core.commands.author.ssp import SSPFilter
@@ -290,6 +291,7 @@ class AuthoredSSP(AuthoredObjectBase):
         input_ssp: str,
         version: str = "",
         profile_name: str = "",
+        main_comp_only: bool = False,
         compdefs: Optional[List[str]] = None,
         implementation_status: Optional[List[str]] = None,
         control_origination: Optional[List[str]] = None,
@@ -302,7 +304,9 @@ class AuthoredSSP(AuthoredObjectBase):
             input_ssp: Input ssp to filter
             version: Optional version to include in the output ssp
             profile_name:  Optional profile to filter by
-            compdefs: Optional list of component definitions to filter by
+            main_comp_only: Optional flag to include only the main component in the output ssp
+            compdefs: Optional list of component definitions to filter by.
+            The main component is added by default.
             implementation_status: Optional implementation status to filter by
             control_origination: Optional control origination to filter by
 
@@ -318,7 +322,7 @@ class AuthoredSSP(AuthoredObjectBase):
 
         components_title: Optional[List[str]] = None
         if compdefs:
-            components_title = []
+            components_title = [SSP_MAIN_COMP_NAME]
             for comp_def_name in compdefs:
                 comp_def, _ = ModelUtils.load_model_for_class(
                     trestle_path, comp_def_name, ComponentDefinition
@@ -326,6 +330,8 @@ class AuthoredSSP(AuthoredObjectBase):
                 components_title.extend(
                     [component.title for component in comp_def.components]
                 )
+        elif main_comp_only:
+            components_title = [SSP_MAIN_COMP_NAME]
 
         try:
             exit_code = ssp_filter.filter_ssp(


### PR DESCRIPTION
## Description

The main component is needed in a trestle SSP for it be valid. This has been added by default when filtering by components in workspace component definitions and option added to filter out all component but the main.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality) **Not user facing feature**

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Updated unit tests

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
