### PR TITLE
chore: removes input repository from the safe workspace

### DIFF
--- a/actions/common.sh
+++ b/actions/common.sh
@@ -6,19 +6,12 @@
 # Manage newest git versions (related to CVE https://github.blog/2022-04-12-git-security-vulnerability-announced/)
 #
 function set_git_safe_directory() {
-    if [[ -z "${GITHUB_WORKSPACE+x}" ]]; then
-    echo "Setting git safe.directory default: /github/workspace ..."
-    git config --global --add safe.directory /github/workspace
+    if [[ -z "${GITHUB_WORKSPACE}" ]]; then
+        echo "GITHUB_WORKSPACE is not set. Exiting..."
+        exit 1
     else
-    echo "Setting git safe.directory GITHUB_WORKSPACE: $GITHUB_WORKSPACE ..."
-    git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    fi
-
-    if [[ -z "${INPUT_REPOSITORY+x}" ]]; then
-        echo "Skipping setting working directory as safe directory"
-    else
-    echo "Setting git safe.directory default: $INPUT_REPOSITORY ..."
-    git config --global --add safe.directory "$INPUT_REPOSITORY"
+        echo "Setting git safe.directory GITHUB_WORKSPACE: $GITHUB_WORKSPACE ..."
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
     fi
 }
 


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

The input repository should always exist in the GitHub workspace. Setting it again in the entrypoint is redundant.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Verified compatibility with GitHub Actions [here](https://github.com/jpower432/cautious-potato/actions/runs/8179086950/job/22364387624)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (on #184)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
