### PR TITLE
fix: removes default version in GitHub action

### DIFF
--- a/actions/autosync/README.md
+++ b/actions/autosync/README.md
@@ -27,7 +27,7 @@ name: Example Workflow
 | oscal_model | OSCAL Model type to assemble. Values can be catalog, profile, compdef, or ssp. | None | True |
 | check_only | Runs tasks and exits with an error if there is a diff. Defaults to false | false | False |
 | github_token | GitHub token used to make authenticated API requests | None | False |
-| version | Version of the OSCAL model to set during assembly into JSON. | 1.0.0 | False |
+| version | Version of the OSCAL model to set during assembly into JSON. | None | False |
 | skip_assemble | Skip assembly task. Defaults to false | false | False |
 | skip_regenerate | Skip regenerate task. Defaults to false. | false | False |
 | skip_items | Comma-separated glob patterns list of content by trestle name to skip during task execution. For example `profile_x,profile_y*,`. | None | False |

--- a/actions/autosync/action.yml
+++ b/actions/autosync/action.yml
@@ -19,7 +19,6 @@ inputs:
   version:
     description: "Version of the OSCAL model to set during assembly into JSON."
     required: false
-    default: "1.0.0"
   skip_assemble:
     description: "Skip assembly task. Defaults to false"
     required: false


### PR DESCRIPTION


## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Removes default version from `autosync` GitHub Action. Default behavior should be to not modify the version value

Fixes #193 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Validated [here](https://github.com/jpower432/trestlebot-demo-cd/actions/runs/8383591343)
Result - https://github.com/jpower432/trestlebot-demo-cd/commit/5d1fd30bd341cd65d71f00a4aba776685e5d8404


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
