### PR TITLE
fix: prevent extra log messages in stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-code-cov:
 # https://github.com/python-poetry/poetry/issues/994#issuecomment-831598242
 # Check for CVEs locally. For continuous dependency updates, we use dependabot.
 dep-cve-check:
-	@poetry export -f requirements.txt --without-hashes | poetry run safety check --stdin
+	@poetry export -f requirements.txt --without-hashes | poetry run safety check --continue-on-error --stdin
 .PHONY: dep-cve-check
 
 security-check:

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -5,6 +5,7 @@
 """Helper functions for unit test setup and teardown."""
 
 import argparse
+import logging
 import pathlib
 import shutil
 import tempfile
@@ -21,6 +22,7 @@ from trestle.oscal import component as comp
 from trestle.oscal import profile as prof
 
 from trestlebot.const import YAML_EXTENSION
+from trestlebot.entrypoints.log import configure_logger
 
 
 JSON_TEST_DATA_PATH = pathlib.Path("tests/data/json/").resolve()
@@ -30,6 +32,17 @@ INVALID_TEST_SSP_INDEX = JSON_TEST_DATA_PATH / "invalid_test_ssp_index.json"
 TEST_YAML_HEADER = YAML_TEST_DATA_PATH / "extra_yaml_header.yaml"
 
 TEST_REMOTE_REPO_URL = "http://localhost:8080/test.git"
+
+
+def configure_test_logger(level: int = logging.INFO) -> None:
+    """
+    Configure the logger for testing.
+
+    Notes: This is used to patch the logger in tests
+    so the caplog can be used to capture log messages.
+    This does not happen when propagate is set to False.
+    """
+    configure_logger(level=level, propagate=True)
 
 
 def clean(repo_path: str, repo: Optional[Repo]) -> None:

--- a/tests/trestlebot/entrypoints/test_autosync.py
+++ b/tests/trestlebot/entrypoints/test_autosync.py
@@ -7,7 +7,7 @@
 import argparse
 import logging
 from typing import Any, Dict
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -15,6 +15,7 @@ from tests.testutils import args_dict_to_list
 from trestlebot.entrypoints.autosync import AutoSyncEntrypoint
 from trestlebot.entrypoints.autosync import main as cli_main
 from trestlebot.entrypoints.entrypoint_base import EntrypointInvalidArgException
+from trestlebot.entrypoints.log import configure_test_logger
 
 
 @pytest.fixture
@@ -60,6 +61,10 @@ def test_validate_args_invalid_model(valid_args_dict: Dict[str, str]) -> None:
             auto_sync.validate_args(args)
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_no_ssp_index(valid_args_dict: Dict[str, str], caplog: Any) -> None:
     """Test missing index file for ssp"""
     args_dict = valid_args_dict
@@ -77,6 +82,10 @@ def test_no_ssp_index(valid_args_dict: Dict[str, str], caplog: Any) -> None:
     )
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_no_markdown_path(valid_args_dict: Dict[str, str], caplog: Any) -> None:
     """Test without a markdown file passed as a flag"""
     args_dict = valid_args_dict
@@ -92,6 +101,10 @@ def test_no_markdown_path(valid_args_dict: Dict[str, str], caplog: Any) -> None:
     )
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_non_existent_working_dir(valid_args_dict: Dict[str, str], caplog: Any) -> None:
     """Test with a non-existent working directory"""
     args_dict = valid_args_dict
@@ -107,6 +120,10 @@ def test_non_existent_working_dir(valid_args_dict: Dict[str, str], caplog: Any) 
     )
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_invalid_working_dir(valid_args_dict: Dict[str, str], caplog: Any) -> None:
     """Test with directory that is not a trestle project root"""
     args_dict = valid_args_dict
@@ -122,6 +139,10 @@ def test_invalid_working_dir(valid_args_dict: Dict[str, str], caplog: Any) -> No
     )
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_with_target_branch(
     tmp_trestle_dir: str, valid_args_dict: Dict[str, str], caplog: Any
 ) -> None:

--- a/tests/trestlebot/entrypoints/test_autosync.py
+++ b/tests/trestlebot/entrypoints/test_autosync.py
@@ -11,11 +11,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from tests.testutils import args_dict_to_list
+from tests.testutils import args_dict_to_list, configure_test_logger
 from trestlebot.entrypoints.autosync import AutoSyncEntrypoint
 from trestlebot.entrypoints.autosync import main as cli_main
 from trestlebot.entrypoints.entrypoint_base import EntrypointInvalidArgException
-from trestlebot.entrypoints.log import configure_test_logger
 
 
 @pytest.fixture

--- a/tests/trestlebot/entrypoints/test_create_cd.py
+++ b/tests/trestlebot/entrypoints/test_create_cd.py
@@ -11,9 +11,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from tests.testutils import args_dict_to_list, setup_for_compdef
+from tests.testutils import args_dict_to_list, configure_test_logger, setup_for_compdef
 from trestlebot.entrypoints.create_cd import main as cli_main
-from trestlebot.entrypoints.log import configure_test_logger
 
 
 @pytest.fixture

--- a/tests/trestlebot/entrypoints/test_create_cd.py
+++ b/tests/trestlebot/entrypoints/test_create_cd.py
@@ -7,12 +7,13 @@
 import logging
 import pathlib
 from typing import Any, Dict
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from tests.testutils import args_dict_to_list, setup_for_compdef
 from trestlebot.entrypoints.create_cd import main as cli_main
+from trestlebot.entrypoints.log import configure_test_logger
 
 
 @pytest.fixture
@@ -49,6 +50,10 @@ def test_create_cd_with_missing_args(
             cli_main()
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_create_cd_with_missing_profile(
     tmp_trestle_dir: str, valid_args_dict: Dict[str, str], caplog: Any
 ) -> None:
@@ -72,6 +77,10 @@ def test_create_cd_with_missing_profile(
     )
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_create_cd_with_missing_filter_profile(
     tmp_trestle_dir: str, valid_args_dict: Dict[str, str], caplog: Any
 ) -> None:

--- a/tests/trestlebot/entrypoints/test_create_ssp.py
+++ b/tests/trestlebot/entrypoints/test_create_ssp.py
@@ -12,9 +12,13 @@ from unittest.mock import Mock, patch
 import pytest
 from git import Repo
 
-from tests.testutils import TEST_YAML_HEADER, args_dict_to_list, setup_for_ssp
+from tests.testutils import (
+    TEST_YAML_HEADER,
+    args_dict_to_list,
+    configure_test_logger,
+    setup_for_ssp,
+)
 from trestlebot.entrypoints.create_ssp import main as cli_main
-from trestlebot.entrypoints.log import configure_test_logger
 
 
 @pytest.fixture

--- a/tests/trestlebot/entrypoints/test_create_ssp.py
+++ b/tests/trestlebot/entrypoints/test_create_ssp.py
@@ -7,13 +7,14 @@
 import logging
 import pathlib
 from typing import Any, Dict, Tuple
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from git import Repo
 
 from tests.testutils import TEST_YAML_HEADER, args_dict_to_list, setup_for_ssp
 from trestlebot.entrypoints.create_ssp import main as cli_main
+from trestlebot.entrypoints.log import configure_test_logger
 
 
 @pytest.fixture
@@ -43,6 +44,10 @@ expected_files = [
 ]
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_create_ssp(
     tmp_repo: Tuple[str, Repo], base_args_dict: Dict[str, str], caplog: Any
 ) -> None:
@@ -78,6 +83,10 @@ def test_create_ssp(
     )
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_create_ssp_with_error(
     tmp_repo: Tuple[str, Repo], base_args_dict: Dict[str, str], caplog: Any
 ) -> None:

--- a/tests/trestlebot/entrypoints/test_sync_upstreams.py
+++ b/tests/trestlebot/entrypoints/test_sync_upstreams.py
@@ -11,8 +11,12 @@ from unittest.mock import Mock, patch
 import pytest
 from git import Repo
 
-from tests.testutils import args_dict_to_list, clean, prepare_upstream_repo
-from trestlebot.entrypoints.log import configure_test_logger
+from tests.testutils import (
+    args_dict_to_list,
+    clean,
+    configure_test_logger,
+    prepare_upstream_repo,
+)
 from trestlebot.entrypoints.sync_upstreams import main as cli_main
 
 

--- a/tests/trestlebot/entrypoints/test_sync_upstreams.py
+++ b/tests/trestlebot/entrypoints/test_sync_upstreams.py
@@ -6,12 +6,13 @@
 
 import logging
 from typing import Any, Dict, Tuple
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from git import Repo
 
 from tests.testutils import args_dict_to_list, clean, prepare_upstream_repo
+from trestlebot.entrypoints.log import configure_test_logger
 from trestlebot.entrypoints.sync_upstreams import main as cli_main
 
 
@@ -122,6 +123,10 @@ def test_with_exclude_model_names(
     clean(source, None)
 
 
+@patch(
+    "trestlebot.entrypoints.log.configure_logger",
+    Mock(side_effect=configure_test_logger),
+)
 def test_with_no_sources(valid_args_dict: Dict[str, str], caplog: Any) -> None:
     """Test with an invalid source argument."""
     args_dict = valid_args_dict

--- a/trestlebot/entrypoints/log.py
+++ b/trestlebot/entrypoints/log.py
@@ -7,6 +7,7 @@
 import argparse
 import logging
 import sys
+from typing import List
 
 import trestle.common.log as log
 
@@ -28,8 +29,29 @@ def set_log_level_from_args(args: argparse.Namespace) -> None:
 
 def configure_logger(level: int = logging.INFO) -> None:
     """Configure the logger."""
+    # Prevent extra message
+    _logger.propagate = False
     _logger.setLevel(level=level)
+    for handler in configure_handlers():
+        _logger.addHandler(handler)
 
+
+def configure_test_logger(level: int = logging.INFO) -> None:
+    """
+    Configure the logger for testing.
+
+    Notes: This is used to patch the logger in tests
+    so the caplog can be used to capture log messages.
+    This does not happen when propagate is set to False.
+    """
+    _logger.propagate = True
+    _logger.setLevel(level=level)
+    for handler in configure_handlers():
+        _logger.addHandler(handler)
+
+
+def configure_handlers() -> List[logging.Handler]:
+    """Configure the handlers."""
     # Create a StreamHandler to send non-error logs to stdout
     stdout_info_handler = logging.StreamHandler(sys.stdout)
     stdout_info_handler.setLevel(logging.INFO)
@@ -49,7 +71,4 @@ def configure_logger(level: int = logging.INFO) -> None:
     )
     stdout_debug_handler.setFormatter(detailed_formatter)
     stderr_handler.setFormatter(detailed_formatter)
-
-    _logger.addHandler(stdout_debug_handler)
-    _logger.addHandler(stdout_info_handler)
-    _logger.addHandler(stderr_handler)
+    return [stdout_debug_handler, stdout_info_handler, stderr_handler]

--- a/trestlebot/entrypoints/log.py
+++ b/trestlebot/entrypoints/log.py
@@ -27,24 +27,10 @@ def set_log_level_from_args(args: argparse.Namespace) -> None:
         configure_logger(logging.INFO)
 
 
-def configure_logger(level: int = logging.INFO) -> None:
+def configure_logger(level: int = logging.INFO, propagate: bool = False) -> None:
     """Configure the logger."""
     # Prevent extra message
-    _logger.propagate = False
-    _logger.setLevel(level=level)
-    for handler in configure_handlers():
-        _logger.addHandler(handler)
-
-
-def configure_test_logger(level: int = logging.INFO) -> None:
-    """
-    Configure the logger for testing.
-
-    Notes: This is used to patch the logger in tests
-    so the caplog can be used to capture log messages.
-    This does not happen when propagate is set to False.
-    """
-    _logger.propagate = True
+    _logger.propagate = propagate
     _logger.setLevel(level=level)
     for handler in configure_handlers():
         _logger.addHandler(handler)


### PR DESCRIPTION
## Description

GitLab CI still logs extra messages with log filtering. Disabling propagation to isolate the trestlbot logger similar to the `compliance-trestle` logger.

Add a fix in tests to ensure logs are still found using `caplog` during test time

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Integration test with GitLab CI
- [X] Verify functionality still works with GitHub Actions - https://github.com/jpower432/cautious-potato/actions/runs/8435478742/job/23100967673

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
