### PR TITLE
PSCE-408 refactor: replaces regex with urllib for repo URL parsing

### DIFF
--- a/tests/trestlebot/test_gitlab.py
+++ b/tests/trestlebot/test_gitlab.py
@@ -94,7 +94,7 @@ def test_parse_repository_with_incorrect_name() -> None:
     gl = GitLab("fake")
     with pytest.raises(
         GitProviderException,
-        match="https://notgitlab.com/owner/repo.git is an invalid repo URL",
+        match="https://notgitlab.com/owner/repo.git is an invalid Gitlab repo URL",
     ):
         gl.parse_repository("https://notgitlab.com/owner/repo.git")
 

--- a/trestlebot/github.py
+++ b/trestlebot/github.py
@@ -4,6 +4,8 @@
 
 """GitHub related functions for the Trestle Bot."""
 
+from __future__ import annotations
+
 import os
 import re
 from typing import Optional, Tuple

--- a/trestlebot/github.py
+++ b/trestlebot/github.py
@@ -31,7 +31,15 @@ class GitHub(GitProvider):
         session.login(token=access_token)
 
         self._session = session
-        self.pattern = r"^(?:https?://)?github\.com/([^/]+)/([^/.]+)"
+
+        # For repo URL input validation
+        pattern = r"^(?:https?://)?github\.com/([^/]+)/([^/.]+)"
+        self._pattern = re.compile(pattern)
+
+    @property
+    def provider_pattern(self) -> re.Pattern[str]:
+        """Regex pattern to validate repository URLs"""
+        return self._pattern
 
     def parse_repository(self, repo_url: str) -> Tuple[str, str]:
         """
@@ -43,11 +51,12 @@ class GitHub(GitProvider):
         Returns:
             Owner and repo name in a tuple, respectively
         """
-
-        match = re.match(self.pattern, repo_url)
+        match: Optional[re.Match[str]]
+        stripped_url: str
+        match, stripped_url = self.match_url(repo_url)
 
         if not match:
-            raise GitProviderException(f"{repo_url} is an invalid GitHub repo URL")
+            raise GitProviderException(f"{stripped_url} is an invalid GitHub repo URL")
 
         owner = match.group(1)
         repo = match.group(2)

--- a/trestlebot/gitlab.py
+++ b/trestlebot/gitlab.py
@@ -4,6 +4,8 @@
 
 """GitLab related functions for the Trestle Bot."""
 
+from __future__ import annotations
+
 import os
 import re
 import time

--- a/trestlebot/provider.py
+++ b/trestlebot/provider.py
@@ -29,14 +29,12 @@ class GitProvider(ABC):
     def match_url(self, repo_url: str) -> Tuple[Optional[re.Match[str]], str]:
         """Match a repository URL with the pattern"""
         parsed_url: ParseResult = urlparse(repo_url)
-        scheme = parsed_url.scheme
-        host = parsed_url.hostname
-        path = parsed_url.path
 
+        path = parsed_url.path
         stripped_url = path
-        if host:
+        if host := parsed_url.hostname:
             stripped_url = f"{host}{path}"
-        if scheme:
+        if scheme := parsed_url.scheme:
             stripped_url = f"{scheme}://{stripped_url}"
         return self.provider_pattern.match(stripped_url), stripped_url
 

--- a/trestlebot/provider.py
+++ b/trestlebot/provider.py
@@ -4,8 +4,10 @@
 
 """Base Git Provider class for the Trestle Bot."""
 
+import re
 from abc import ABC, abstractmethod
-from typing import Tuple
+from typing import Optional, Tuple
+from urllib.parse import ParseResult, urlparse
 
 
 class GitProviderException(Exception):
@@ -16,6 +18,25 @@ class GitProvider(ABC):
     """
     Abstract base class for Git provider types
     """
+
+    @property
+    @abstractmethod
+    def provider_pattern(self) -> re.Pattern[str]:
+        """Regex pattern to validate repository URLs"""
+
+    def match_url(self, repo_url: str) -> Tuple[Optional[re.Match[str]], str]:
+        """Match a repository URL with the pattern"""
+        parsed_url: ParseResult = urlparse(repo_url)
+        scheme = parsed_url.scheme
+        host = parsed_url.hostname
+        path = parsed_url.path
+
+        stripped_url = path
+        if host:
+            stripped_url = f"{host}{path}"
+        if scheme:
+            stripped_url = f"{scheme}://{stripped_url}"
+        return self.provider_pattern.match(stripped_url), stripped_url
 
     @abstractmethod
     def parse_repository(self, repository_url: str) -> Tuple[str, str]:

--- a/trestlebot/provider.py
+++ b/trestlebot/provider.py
@@ -4,6 +4,8 @@
 
 """Base Git Provider class for the Trestle Bot."""
 
+from __future__ import annotations
+
 import re
 from abc import ABC, abstractmethod
 from typing import Optional, Tuple


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

In `GitProvider` class and concrete implementations, move any repo url string parsing to `urllib` and only use regex for path pattern matching and capturing. Also removes `regex` related code smell.

Prep for #200 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue) (**Refactor**)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Regression Testing
  - [X] GitHub - https://github.com/jpower432/cautious-potato/actions/runs/8970170952
  - [x] GitLab 

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
