### PR TITLE
ci: pins all reference GitHub actions to a hash value

### DIFF
--- a/.github/actions/e2e-testing/action.yml
+++ b/.github/actions/e2e-testing/action.yml
@@ -2,14 +2,14 @@ name: "e2e-testing"
 description: "Composite action for trestle-bot end-to-end tests."
 
 inputs:
-    build:
-      description: "Whether to build the image before testing."
-      required: false
-      default: "true"
-    image:
-      description: |
-        "Name of the trestlebot image you want to test if pre-existing. Required if build is false."
-      required: false
+  build:
+    description: "Whether to build the image before testing."
+    required: false
+    default: "true"
+  image:
+    description: |
+      "Name of the trestlebot image you want to test if pre-existing. Required if build is false."
+    required: false
 
 runs:
   using: "composite"
@@ -23,8 +23,8 @@ runs:
     - name: Pull the image
       if: ${{ inputs.build == 'false' }}
       run: |
-          podman pull "${IMAGE}"
-          echo "TRESTLEBOT_IMAGE=$(sed -e 's/^docker-daemon://' <<<${IMAGE})" >> "$GITHUB_ENV"
+        podman pull "${IMAGE}"
+        echo "TRESTLEBOT_IMAGE=$(sed -e 's/^docker-daemon://' <<<${IMAGE})" >> "$GITHUB_ENV"
       env:
         IMAGE: ${{ inputs.image }}
       shell: bash
@@ -32,4 +32,3 @@ runs:
     - name: Run tests
       run: make test-e2e
       shell: bash
-  

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -28,15 +28,15 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # pin@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # pin@v3
 
     # Tags are defined here based on workflow triggers
     - name: Define metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # pin@v5
       with:
         images: ${{ inputs.image }}
         tags: |
@@ -47,9 +47,9 @@ runs:
           type=schedule,pattern={{date 'YYYYMMDD'}},prefix=${{ inputs.release_version }}.
         flavor: |
           latest=false
-    
+
     - name: Build and export to Docker
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # pin@v5
       id: build-and-export
       with:
         context: "${{ github.server_url }}/${{ github.repository }}.git#${{ inputs.git_ref }}"
@@ -59,16 +59,16 @@ runs:
         cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-    
+
     - name: Pre-push Image Scan
-      uses: aquasecurity/trivy-action@0.19.0
+      uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # pin@0.19.0
       with:
         image-ref: ${{ inputs.image }}:${{ steps.meta.outputs.version }}
         exit-code: 1
-        skip-files:  "**/.venv/lib/**/METADATA"
+        skip-files: "**/.venv/lib/**/METADATA"
         scanners: secret
         severity: HIGH,CRITICAL,MEDIUM
-    
+
     - name: Pre-push testing
       if: ${{ inputs.skip_tests == 'false' }}
       uses: ./.github/actions/e2e-testing
@@ -78,7 +78,7 @@ runs:
 
     # Does not rebuild. Uses internal cache from previous step.
     - name: Build and Push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # pin@v5
       id: build-and-push
       with:
         context: "${{ github.server_url }}/${{ github.repository }}.git#${{ inputs.git_ref }}"

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -7,9 +7,9 @@ inputs:
     description: "The poetry version to use"
     default: "1.7.1"
   python-version:
-     required: false
-     description: "The python version to use"
-     default: "3.11"
+    required: false
+    description: "The python version to use"
+    default: "3.11"
 
 runs:
   using: "composite"
@@ -19,7 +19,7 @@ runs:
       shell: bash
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # pin@v5
       with:
         python-version: ${{ inputs.python-version }}
         cache: poetry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ name: CI
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
-    branches: 
-    - main
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-ci
@@ -21,34 +21,34 @@ jobs:
       issues: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # pin@v4
 
       - name: MegaLinter
         id: ml
-        uses: oxsecurity/megalinter@v7
+        uses: oxsecurity/megalinter@5199c6377b4cb7faff749a1971636f3343db9fe6 # pin@v7
         env:
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
   project_checks:
     name: Run project checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # pin@v4
+
       - name: Set up poetry and install
         uses: ./.github/actions/setup-poetry
 
       - name: Pre-commit install
         run: make pre-commit
-      
+
       - name: Run linting checks
         run: make lint
-      
+
       - name: Run security checks
         run: make security-check
-      
+
       - name: Check dependencies
         run: make dep-cve-check
 
@@ -56,12 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
       fail-fast: false
     steps:
       - name: Check out
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # pin@v4
+
       - name: Set up poetry and install
         uses: ./.github/actions/setup-poetry
         with:
@@ -76,5 +76,5 @@ jobs:
       contents: read
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # pin@v4
       - uses: ./.github/actions/e2e-testing

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,14 +9,13 @@ on:
     paths:
       - '**.py'
 
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # pin@v4
+
       - name: Set up poetry and install
         uses: ./.github/actions/setup-poetry
         with:
@@ -24,9 +23,9 @@ jobs:
 
       - name: Run tests
         run: make test-code-cov
-      
+
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # pin@v4
         with:
           name: coverage
           path: coverage.xml
@@ -36,28 +35,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # pin@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Get coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # pin@v4
         with:
           name: coverage
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9
+        uses: SonarSource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # pin@49e6cd3b187936a73b8280d59ffd9da69df63ec9
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
-            -Dsonar.python.coverage.reportPaths=coverage.xml
-            -Dsonar.tests=tests/
-            -Dsonar.sources=trestlebot/ 
-            -Dsonar.python.version=3.10
-            -Dsonar.projectKey=rh-psce_trestle-bot
-            -Dsonar.organization=rh-psce
+            -Dsonar.python.coverage.reportPaths=coverage.xml -Dsonar.tests=tests/ -Dsonar.sources=trestlebot/  -Dsonar.python.version=3.10 -Dsonar.projectKey=rh-psce_trestle-bot -Dsonar.organization=rh-psce
       - name: SonarQube Quality Gate check
-        uses: sonarsource/sonarqube-quality-gate-action@f9fe214a5be5769c40619de2fff2726c36d2d5eb
+        uses: sonarsource/sonarqube-quality-gate-action@f9fe214a5be5769c40619de2fff2726c36d2d5eb # pin@f9fe214a5be5769c40619de2fff2726c36d2d5eb
         # Force to fail step after specific time
         timeout-minutes: 5
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: 0 0 */30 * *
   release:
-    types: [published]
+    types: [ published ]
   workflow_dispatch:
     inputs:
       tag:
@@ -24,8 +24,8 @@ on:
         required: false
         default: false
 env:
-    IMAGE_NAME: trestle-bot
-    IMAGE_REGISTRY: quay.io
+  IMAGE_NAME: trestle-bot
+  IMAGE_REGISTRY: quay.io
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-publish
@@ -40,24 +40,24 @@ jobs:
       id-token: write # needed for signing the images with GitHub OIDC Token
     steps:
       - name: Login to Quay
-        uses: docker/login-action@v3
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # pin@v3
         with:
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
           registry: ${{ env.IMAGE_REGISTRY }}
-      
+
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # pin@v4
         with:
           persist-credentials: false
-      
+
       - name: Set up cosign
-        uses: sigstore/cosign-installer@v3.5.0
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # pin@v3.5.0
 
       - name: Check if triggered by release or workflow dispatch
         id: check_event
         run: echo "event_type=${{ toJson(github.event_name) }}" >> "$GITHUB_OUTPUT"
-        
+
       # Using intermediary variable to process event based input
       - name: Set environment information for release
         if: ${{ steps.check_event.outputs.event_type == 'release' }}
@@ -107,7 +107,7 @@ jobs:
           no_cache: ${{ env.NO_CACHE }}
           git_ref: ${{ env.BUILD_GIT_REF }}
           skip_tests: ${{ env.SKIP_TESTS }}
-      
+
       - name: Sign the image with GitHub OIDC Token
         run: cosign sign --yes "$IMAGE"
         env:


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Pinning GitHub Actions to a commit-sha is a safer practice and supported by Dependabot for continuous updates

## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality) **Maintenance Only**

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Verify changes locally with act
- [X] Verify changes in fork with GitHub Actions
   - Demonstrated `ci.yml` with this PR
   - Publish -  https://github.com/jpower432/trestle-bot/actions/runs/9422275168/job/25958179482

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
