### PR TITLE
fix: updates GitHub Actions runner image and restart policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: make test
 
   e2e-test:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-24.04'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   publish-image:
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04'
     permissions:
       contents: read
       # kics-scan ignore-line

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@
 import argparse
 import logging
 import pathlib
-from tempfile import TemporaryDirectory
+import tempfile
 from typing import Any, Dict, Generator, Tuple, TypeVar
 
 import pytest
@@ -36,23 +36,23 @@ _TEST_PREFIX = "trestlebot_tests"
 @pytest.fixture(scope="function")
 def tmp_repo() -> YieldFixture[Tuple[str, Repo]]:
     """Create a temporary git repository with an initialized trestle workspace root"""
-    with TemporaryDirectory(prefix=_TEST_PREFIX) as tmpdir:
-        tmp_path = pathlib.Path(tmpdir)
-        repo: Repo = repo_setup(tmp_path)
-        remote_url = "http://localhost:8080/test.git"
-        repo.create_remote("origin", url=remote_url)
-        yield tmpdir, repo
+    tmpdir = tempfile.mkdtemp(prefix=_TEST_PREFIX)
+    tmp_path = pathlib.Path(tmpdir)
+    repo: Repo = repo_setup(tmp_path)
+    remote_url = "http://localhost:8080/test.git"
+    repo.create_remote("origin", url=remote_url)
+    yield tmpdir, repo
 
-        try:
-            clean(tmpdir, repo)
-        except Exception as e:
-            logging.error(f"Failed to clean up temporary git repository: {e}")
+    try:
+        clean(tmpdir, repo)
+    except Exception as e:
+        logging.error(f"Failed to clean up temporary git repository: {e}")
 
 
 @pytest.fixture(scope="function")
 def tmp_trestle_dir() -> YieldFixture[str]:
     """Create an initialized temporary trestle directory"""
-    with TemporaryDirectory(prefix=_TEST_PREFIX) as tmpdir:
+    with tempfile.TemporaryDirectory(prefix=_TEST_PREFIX) as tmpdir:
         tmp_path = pathlib.Path(tmpdir)
         try:
             args = argparse.Namespace(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@
 """Common test fixtures."""
 
 import argparse
-import logging
 import pathlib
 import tempfile
 from typing import Any, Dict, Generator, Tuple, TypeVar
@@ -42,11 +41,7 @@ def tmp_repo() -> YieldFixture[Tuple[str, Repo]]:
     remote_url = "http://localhost:8080/test.git"
     repo.create_remote("origin", url=remote_url)
     yield tmpdir, repo
-
-    try:
-        clean(tmpdir, repo)
-    except Exception as e:
-        logging.error(f"Failed to clean up temporary git repository: {e}")
+    clean(tmpdir, repo)
 
 
 @pytest.fixture(scope="function")

--- a/tests/e2e/e2e_testutils.py
+++ b/tests/e2e/e2e_testutils.py
@@ -144,7 +144,8 @@ class E2ETestRunner:
             E2ETestRunner.TRESTLEBOT_TEST_POD_NAME,
             "--entrypoint",
             f"trestlebot-{command_name}",
-            "--rm",
+            "--restart",
+            "never",
         ]
 
         # Add mounts

--- a/tests/trestlebot/tasks/test_sync_upstream_task.py
+++ b/tests/trestlebot/tasks/test_sync_upstream_task.py
@@ -104,9 +104,8 @@ def test_sync_upstream_invalid_git(
 ) -> None:
     """Test sync upstreams task with invalid git source"""
     tmp_repo_path, _ = tmp_repo
-    # Now remove the git repo
-    shutil.rmtree(tmp_repo_path)
-    sync = SyncUpstreamsTask(tmp_trestle_dir, [f"{tmp_repo_path}@main"])
+    new_path = f"{tmp_repo_path}1"
+    sync = SyncUpstreamsTask(tmp_trestle_dir, [f"{new_path}@main"])
     with pytest.raises(
         TaskException, match="Git error occurred while fetching content from .*"
     ):

--- a/tests/trestlebot/test_github.py
+++ b/tests/trestlebot/test_github.py
@@ -13,7 +13,7 @@ import pytest
 from git.repo import Repo
 from responses import GET, POST, RequestsMock
 
-from tests.testutils import JSON_TEST_DATA_PATH, clean
+from tests.testutils import JSON_TEST_DATA_PATH
 from trestlebot.github import GitHub, GitHubActionsResultsReporter, set_output
 from trestlebot.provider import GitProviderException
 from trestlebot.reporter import BotResults
@@ -49,8 +49,6 @@ def test_parse_repository_integration(tmp_repo: Tuple[str, Repo]) -> None:
 
     assert owner == "test"
     assert repo_name == "repo"
-
-    clean(repo_path, repo)
 
 
 def test_parse_repository_with_incorrect_name() -> None:

--- a/tests/trestlebot/test_gitlab.py
+++ b/tests/trestlebot/test_gitlab.py
@@ -12,7 +12,6 @@ from git.repo import Repo
 from gitlab.exceptions import GitlabAuthenticationError, GitlabCreateError
 from responses import GET, POST, RequestsMock
 
-from tests.testutils import clean
 from trestlebot.gitlab import GitLab, GitLabCIResultsReporter
 from trestlebot.provider import GitProviderException
 from trestlebot.reporter import BotResults
@@ -85,8 +84,6 @@ def test_parse_repository_integration(tmp_repo: Tuple[str, Repo]) -> None:
 
     assert owner == "test"
     assert repo_name == "repo"
-
-    clean(repo_path, repo)
 
 
 def test_parse_repository_with_incorrect_name() -> None:


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Changes

- Ubuntu 24.04 has version 4 of `podman` which is compatible with version of Docker (*Note* - this public [beta](https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/) slated to go GA in [Sept](https://github.com/github/roadmap/issues/980))
- v4 of podman has a default restart policy of always which cause unexpected behavior during tests (follow-on issue will be needed for this).

## Rationale

Why use `podman` and `docker`?

They are used in different contexts. `podman` is used to manage containers in E2E testing. `docker` GitHub Actions are used for image building in the release pipeline.

- Using `podman` pods is required to run the mock server and trestle-bot on the same network stack. It is also what the team is more familiar with.
- In terms of `image` building in GitHub Actions, the `docker` actions have the features we need for image tag management and caching.

## Alternatives 

> Open to discuss here or on the issue

- Choose a single technology
- Install Podman v4 on existing `ubuntu-latest`. This is possible through brew or manually, but we would need to back out the changes in Sept.

Fixes #251 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Verified Success -  https://github.com/RedHatProductSecurity/trestle-bot/actions/runs/9786753498/job/27022159330

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
