### PR TITLE
chore: change dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,14 @@ updates:
       - '/.github/actions/publish-image'
       - '/.github/actions/setup-poetry'
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: ":arrow_up:"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     allow:
       - dependency-type: "all"
     commit-message:


### PR DESCRIPTION
## Description

Reduces `dependabot` run frequency from daily to weekly.  This allows for a more manageable rate of PRs to address version updates.

Fixes [Issue #285](https://github.com/RedHatProductSecurity/trestle-bot/issues/285) 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [X] Validated YAML

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
