### PR TITLE
fix: updates dependabot prefix for conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,8 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: ":arrow_up:"
+      prefix: build
+      include: scope
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -19,4 +20,5 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: ":arrow_up:"
+      prefix: build
+      include: scope


### PR DESCRIPTION
## Description

Updates the dependabot prefix to ensure the PR title are using Conventional Commits

Fixes #306 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

N/A

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
