### PR TITLE
feat: update module default to use init entrypoint

### DIFF
--- a/trestlebot/__main__.py
+++ b/trestlebot/__main__.py
@@ -4,13 +4,13 @@
 
 # Default entrypoint for trestlebot is autosync mode when run with python -m trestlebot
 
-from trestlebot.entrypoints.autosync import main as autosync_main
+from trestlebot.entrypoints.init import main as init_main
 
 
 def init() -> None:
     """Initialize trestlebot"""
     if __name__ == "__main__":
-        autosync_main()
+        init_main()
 
 
 init()


### PR DESCRIPTION
## Description

This PR changes the default trestlebot module behavior to invoke the `init` entrypoint instead of the `autosync` entrypoint.  

## Type of change

- [X]  Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How has this been tested?

- [X] Tested locally using `python -m trestlebot` to ensure init was invoked
- [X] All unit tests passed


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
