### PR TITLE
fix: updates e2e tests checkout ref during image publishing

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -8,9 +8,6 @@ inputs:
   release_version:
     required: true
     description: The version to build type semver tags from
-  git_ref:
-    required: true
-    description: The git reference to build image from
   no_cache:
     description: Skip using cache when building the image.
     required: false
@@ -52,7 +49,7 @@ runs:
       uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # pin@v5
       id: build-and-export
       with:
-        context: "${{ github.server_url }}/${{ github.repository }}.git#${{ inputs.git_ref }}"
+        context: "."
         load: true
         no-cache: ${{ inputs.no_cache == 'true' }}
         cache-from: type=gha
@@ -81,7 +78,7 @@ runs:
       uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # pin@v5
       id: build-and-push
       with:
-        context: "${{ github.server_url }}/${{ github.repository }}.git#${{ inputs.git_ref }}"
+        context: "."
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,11 +46,6 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
           registry: ${{ env.IMAGE_REGISTRY }}
 
-      - name: Check out
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
-        with:
-          persist-credentials: false
-
       - name: Set up cosign
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # pin@v3.5.0
 
@@ -97,6 +92,12 @@ jobs:
           } >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Check out
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        with:
+          ref: ${{ env.BUILD_GIT_REF }}
+          persist-credentials: false
 
       - name: Build and Publish the image
         uses: ./.github/actions/publish-image
@@ -105,7 +106,6 @@ jobs:
           image: ${{ env.IMAGE_REGISTRY }}/${{ vars.QUAY_ORG }}/${{ env.IMAGE_NAME }}
           release_version: ${{ env.TAG }}
           no_cache: ${{ env.NO_CACHE }}
-          git_ref: ${{ env.BUILD_GIT_REF }}
           skip_tests: ${{ env.SKIP_TESTS }}
 
       - name: Sign the image with GitHub OIDC Token


### PR DESCRIPTION

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

When rebuilding old images, we need to run the E2E from that references to avoid issues with breaking changes in the CLI. This solution checks out the git repository at the references determined by the trigger and uses the Docker `build-push` action with a path context.

Fixes #332 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] https://github.com/RedHatProductSecurity/trestle-bot/actions/runs/10600722915
- [x] Local testing and inspection of image produced

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
