### PR TITLE
fix: add markdown-include package to workflow and poetry

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -22,5 +22,5 @@ jobs:
         with:
           key: ${{ github.ref }}
           path: .cache
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material markdown-include
       - run: mkdocs gh-deploy --force

--- a/poetry.lock
+++ b/poetry.lock
@@ -1121,6 +1121,23 @@ docs = ["mdx-gh-links (>=0.2)", "mkdocs (>=1.5)", "mkdocs-gen-files", "mkdocs-li
 testing = ["coverage", "pyyaml"]
 
 [[package]]
+name = "markdown-include"
+version = "0.8.1"
+description = "A Python-Markdown extension which provides an 'include' function"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "markdown-include-0.8.1.tar.gz", hash = "sha256:1d0623e0fc2757c38d35df53752768356162284259d259c486b4ab6285cdbbe3"},
+    {file = "markdown_include-0.8.1-py3-none-any.whl", hash = "sha256:32f0635b9cfef46997b307e2430022852529f7a5b87c0075c504283e7cc7db53"},
+]
+
+[package.dependencies]
+markdown = ">=3.0"
+
+[package.extras]
+tests = ["pytest"]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -2585,4 +2602,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "4a8eea1af39dae299c2000af88cfd50760a2a762498816238c5a0b8287fb7e78"
+content-hash = "97ef7c1ede0e64754d45dc505b33d53cefeabb4083e64ba67e5cba57cbe10f90"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ safety = "^3.1.0"
 flake8-print = "^5.0.0"
 pre-commit = "^3.4.0"
 mkdocs-material = "^9.5.31"
+markdown-include = "^0.8.1"
 
 [tool.poetry.group.tests.dependencies]
 pytest = "^8.3.2"


### PR DESCRIPTION
## Description

Adds the `markdown-include` package to the `publish-docs` GitHub workflow and poetry dev group.

Fixes https://github.com/RedHatProductSecurity/trestle-bot/issues/338

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [X] Ran `poetry install --with dev` localy

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
