### PR TITLE
feat(bot): change for configuring trestle-bot PR body update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: develop lint test
 .PHONY: all
 
 develop: pre-commit
-	@poetry install
+	@poetry install --with tests,dev
 	@poetry shell
 .PHONY: develop
 

--- a/tests/trestlebot/test_bot.py
+++ b/tests/trestlebot/test_bot.py
@@ -347,7 +347,7 @@ def test_run_with_provider(tmp_repo: Tuple[str, Repo]) -> None:
             head_branch="test",
             base_branch="main",
             title="Automatic updates from bot",
-            body="",
+            body="Authored by trestle-bot.",
         )
         mock_push.assert_called_once_with(refspec="HEAD:test")
 
@@ -396,6 +396,6 @@ def test_run_with_provider_with_custom_pr_title(tmp_repo: Tuple[str, Repo]) -> N
             head_branch="test",
             base_branch="main",
             title="Test",
-            body="",
+            body="Authored by trestle-bot.",
         )
         mock_push.assert_called_once_with(refspec="HEAD:test")

--- a/trestlebot/bot.py
+++ b/trestlebot/bot.py
@@ -120,7 +120,7 @@ class TrestleBot:
             head_branch=self.branch,
             base_branch=self.target_branch,
             title=pull_request_title,
-            body="",
+            body="Authored by trestle-bot.",
         )
         return pr_number
 


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.--> The changes made allow the body of the pull request submitted by trestle-bot to be configured as "Authored by trestle-bot." The changed parameter allows for configuring the PR submitted by trestle-bot to provide additional context for the user. The Makefile develop test case change allows for proper local working privileges. 

Closes #320

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] The commands `make test` and `make develop` were run on the command line to validate the test cases.
- [x] Tests run using poetry were performed using `poetry install --with tests,dev ` on the command line. The Makefile has the matching make develop `poetry install --with tests,dev` [command](Makefile). The Semgrep tests were used for checking pre-commit. 

**Test Configuration**:

- Firmware version: N/A
- Hardware: Lenovo ThinkPad P1 Gen 4i
- Toolchain: N/A
- SDK: N/A

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
