### PR TITLE
fix: run the paths-filter step in its own job

### DIFF
--- a/TEMPLATES/github/trestlebot-rules-transform.yml
+++ b/TEMPLATES/github/trestlebot-rules-transform.yml
@@ -17,11 +17,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_rules:
+    runs-on: ubuntu-latest
+    outputs:
+      rules_changed: ${{ steps.changes.outputs.rules }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        filters: |
+          rules:
+            - 'rules/**'
   rules-transform-and-autosync:
     name: Rules Transform and AutoSync
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    needs: check_rules
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,16 +44,9 @@ jobs:
         with:
           markdown_path: "markdown/component-definitions"
           oscal_model: "compdef"
-          file_pattern: "*.json,markdown/*"
-      - name: Check if rules changed
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            rules:
-              - 'rules/**'
+          commit_message: "Autosync component definition content [skip ci]"
       - name: Rules Transform
-        if: steps.changes.outputs.rules == 'true'
+        if: needs.check_rules.outputs.rules_changed == 'true'
         uses: RedHatProductSecurity/trestle-bot/actions/rules-transform@main
         with:
           markdown_path: "markdown/component-definitions"


### PR DESCRIPTION
## Description

Fixes an issue where the paths-filter job fails after the first run

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] https://github.com/jpower432/trestlebot-init-test/actions/runs/11412540883

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
