### PR TITLE
docs: authoring CI workflows for trestle-bot section in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Before you start contributing, please take a moment to read through the guide be
     - [Documentation](#documentation)
       - [Architecture Decisions](#architecture-decisions)
       - [Update the `actions` files](#update-the-actions-files)
+      - [Authoring CI Workflows](#authoring-ci-workflows)
     - [License Text in Files](#license-text-in-files)
     - [Tools](#tools)
       - [Format and Styling](#format-and-styling)
@@ -97,7 +98,18 @@ Each `README.md` under the `actions` directory have an Actions Inputs and Action
 make update-action-readmes
 ```
 
-### License Text in Files
+#### Authoring CI Workflows
+
+The CI workflows for trestle-bot leverage third party actions pinned to a hash value which is updated by `dependabot.yml`. The purpose of pinning actions to a full length commit SHA is to ensure that action repository privileges are secure. Actions that are pinned to full length commit SHAs act as immutable releases which allow for distinction between versions and an accurate history log. When selecting a commit SHA to include, the SHA value that is associated with the version of the action should be chosen from the associated action's repository. Dependabot checks for the action's reference against the latest version ensuring a secure and consistent approach to managing dependencies and version updating.
+
+To generate a pin for a third party action, there should be a full length commit SHA associated with the version of the action being referenced. The pin used is the full length SHA, tag, or branch that dependabot will reference when updating dependencies and bumping versions.
+
+- The syntax for a specified action is: `OWNER/REPOSITORY@TAG-OR-SHA`.
+- The syntax for a specified reusable workflow is: `OWNER/REPOSITORY/PATH/FILENAME@TAG-OR-SHA`.
+
+This approach is used for authoring CI workflows that utilize versioned actions to produce frequent updates from dependabot for python and GitHub Actions.
+
+### License Text in Files 
 
 Please use the SPDX license identifier in all source files.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,9 @@ make update-action-readmes
 
 #### Authoring CI Workflows
 
-The CI workflows for trestle-bot leverage third party actions pinned to a hash value which is updated by `dependabot.yml`. The purpose of pinning actions to a full length commit SHA is to ensure that action repository privileges are secure. Actions that are pinned to full length commit SHAs act as immutable releases which allow for distinction between versions and an accurate history log. When selecting a commit SHA to include, the SHA value that is associated with the version of the action should be chosen from the associated action's repository. Dependabot checks for the action's reference against the latest version ensuring a secure and consistent approach to managing dependencies and version updating.
+The CI workflows for trestle-bot leverage third party actions pinned to a hash value which is updated by `dependabot.yml`. The purpose of pinning actions to a full length commit SHA is to ensure that the action's code and behavior remain consistent. Actions that are pinned to full length commit SHAs act as immutable releases which allow for distinction between versions and an accurate history log. When selecting a commit SHA to include, the SHA value that is associated with the version of the action should be chosen from the associated action's repository. Dependabot checks for the action's reference against the latest version ensuring a secure and consistent approach to managing dependencies and version updating.
 
-To generate a pin for a third party action, there should be a full length commit SHA associated with the version of the action being referenced. The pin used is the full length SHA, tag, or branch that dependabot will reference when updating dependencies and bumping versions.
+To generate a pin for a third party action, there should be a full length commit SHA associated with the version of the action being referenced. The reference used is the full length SHA, tag, or branch that dependabot will use when updating dependencies and bumping versions.
 
 - The syntax for a specified action is: `OWNER/REPOSITORY@TAG-OR-SHA`.
 - The syntax for a specified reusable workflow is: `OWNER/REPOSITORY/PATH/FILENAME@TAG-OR-SHA`.


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

The changes made to the `CONTRIBUTING.md` guide include a section on "Authoring CI Workflows." The changes outline the importance of using third party actions pinned to hash values for secure maintenance of dependencies and version updates. The changes made highlight the pin generation syntax that references the full length commit SHA associated with the version of the action within the action's repository.


Fixes #317

## Type of change

<!--Please delete options that are not relevant.-->


- [X] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] The tests run to verify changes were `make test`, `make lint`, `make develop`, and `make all` from the trestle-bot Makefile.

**Test Configuration**:

- Firmware version: N40ET47W (1.29)
- Hardware: Lenovo ThinkPad P1 Gen 4i
- Toolchain:
- SDK:

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
