### PR TITLE
fix: update create command for e2e testing

### DIFF
--- a/trestlebot/cli/commands/create.py
+++ b/trestlebot/cli/commands/create.py
@@ -110,7 +110,7 @@ def compdef_cmd(
     transformer: ToRulesYAMLTransformer = ToRulesYAMLTransformer()
 
     model_filter: ModelFilter = ModelFilter(
-        [], [profile_name, component_title, f"{const.RULE_PREFIX}*"]
+        [], [compdef_name, component_title, f"{const.RULE_PREFIX}*"]
     )
 
     rule_transform_task: RuleTransformTask = RuleTransformTask(


### PR DESCRIPTION

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

The fix made to `create.py` corrects the previously indicated `profile_name` to now reference`compdef_name` for correct interaction with the model filter task.  The change made allows for the e2e test to create the .JSON file that previously was not being created.

Fixes #391 
Depends on #389 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] GitHub Actions e2e testing 
- [X] Podman runner

**Test Configuration**:

- Firmware version: N40ET47W (1.29 )
- Hardware: Lenovo ThinkPad P1 Gen 4i
- Toolchain:
- SDK:

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
